### PR TITLE
oracle module implementation

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -14,9 +14,11 @@
     "@chenaikit/core": "workspace:*",
     "@nestjs/common": "^11.1.12",
     "@nestjs/core": "^11.1.12",
+    "@nestjs/mapped-types": "*",
     "@nestjs/platform-express": "^11.1.12",
     "cors": "^2.8.5",
     "dotenv": "^16.0.0",
+    "ethers": "^6.16.0",
     "express": "^4.18.0",
     "helmet": "^7.0.0",
     "reflect-metadata": "^0.2.2"

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -10,9 +10,10 @@ import { SubmitterModule } from './submitter/submitter.module';
 import { ComputeBridgeModule } from './compute-bridge/compute-bridge.module';
 import { AgentModule } from './agent/agent.module';
 import { AuditLogModule } from './audit/audit-log.module';
+import { OracleModule } from './oracle/oracle.module';
 
 @Module({
-  imports: [SimulatorModule],
+  imports: [SimulatorModule, OracleModule],
   controllers: [AppController],
 })
 export class AppModule {}

--- a/backend/src/oracle/_tests_/oracle.service.spec.ts
+++ b/backend/src/oracle/_tests_/oracle.service.spec.ts
@@ -1,0 +1,36 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { OracleService } from '../oracle.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { OracleSnapshot } from '../entities/oracle-snapshot.entity';
+import { OracleLatestPrice } from '../entities/oracle-latest.entity';
+import { Repository } from 'typeorm';
+import { ethers } from 'ethers';
+
+// NOTE: This is an outline. Prefer to use an actual test database or TypeORM in-memory tooling.
+
+describe('OracleService', () => {
+  let service: OracleService;
+  let snapshotRepo: Repository<OracleSnapshot>;
+  let latestRepo: Repository<OracleLatestPrice>;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OracleService,
+        { provide: getRepositoryToken(OracleSnapshot), useValue: {} },
+        { provide: getRepositoryToken(OracleLatestPrice), useValue: {} },
+      ],
+    }).compile();
+
+    service = module.get<OracleService>(OracleService);
+  });
+
+  it('verifies signature and rejects invalid signer', async () => {
+    // Create a test payload and sign with a keypair that is not the configured ORACLE_SIGNER_ADDRESS,
+    // assert UnauthorizedException is thrown.
+  });
+
+  it('stores snapshot and updates latest', async () => {
+    // Sign payload with configured key, call updateSnapshot, then getLatest and assert values.
+  });
+});

--- a/backend/src/oracle/dto/create-oracle.dto.ts
+++ b/backend/src/oracle/dto/create-oracle.dto.ts
@@ -1,0 +1,1 @@
+export class CreateOracleDto {}

--- a/backend/src/oracle/dto/update-oracle.dto.ts
+++ b/backend/src/oracle/dto/update-oracle.dto.ts
@@ -1,0 +1,32 @@
+import { IsArray, IsInt, IsNotEmpty, IsNumberString, IsString, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class OracleFeedDto {
+  @IsString()
+  @IsNotEmpty()
+  pair: string;
+
+  // price as string to avoid JS float rounding; store as numeric in DB
+  @IsNumberString()
+  price: string;
+
+  @IsInt()
+  decimals: number;
+}
+
+export class UpdateOracleDto {
+  @IsInt()
+  timestamp: number; // unix seconds (or ms) — standardize in your app
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => OracleFeedDto)
+  feeds: OracleFeedDto[];
+
+  @IsString()
+  @IsNotEmpty()
+  signature: string;
+
+  @IsString()
+  signer?: string; // optional, can be derived from signature verification
+}

--- a/backend/src/oracle/entities/oracle-latest.entity.ts
+++ b/backend/src/oracle/entities/oracle-latest.entity.ts
@@ -1,0 +1,26 @@
+import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn, Unique } from 'typeorm';
+
+@Entity({ name: 'oracle_latest_prices' })
+@Unique(['pair'])
+export class OracleLatestPrice {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'text' })
+  pair: string;
+
+  @Column({ type: 'numeric' })
+  price: string;
+
+  @Column({ type: 'int' })
+  decimals: number;
+
+  @Column({ type: 'timestamptz' })
+  timestamp: Date;
+
+  @Column({ type: 'uuid' })
+  snapshotId: string;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  updatedAt: Date;
+}

--- a/backend/src/oracle/entities/oracle-snapshot.entity.ts
+++ b/backend/src/oracle/entities/oracle-snapshot.entity.ts
@@ -1,0 +1,22 @@
+import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity({ name: 'oracle_snapshots' })
+export class OracleSnapshot {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'timestamptz' })
+  timestamp: Date;
+
+  @Column({ type: 'text' })
+  signer: string;
+
+  @Column({ type: 'text' })
+  signature: string;
+
+  @Column({ type: 'jsonb' })
+  feeds: any; // array of { pair, price, decimals }
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date;
+}

--- a/backend/src/oracle/entities/oracle.entity.ts
+++ b/backend/src/oracle/entities/oracle.entity.ts
@@ -1,0 +1,1 @@
+export class Oracle {}

--- a/backend/src/oracle/oracle.controller.spec.ts
+++ b/backend/src/oracle/oracle.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { OracleController } from './oracle.controller';
+import { OracleService } from './oracle.service';
+
+describe('OracleController', () => {
+  let controller: OracleController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [OracleController],
+      providers: [OracleService],
+    }).compile();
+
+    controller = module.get<OracleController>(OracleController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/oracle/oracle.controller.ts
+++ b/backend/src/oracle/oracle.controller.ts
@@ -1,0 +1,21 @@
+import { Body, Controller, Get, Post } from '@nestjs/common';
+import { UpdateOracleDto } from './dto/update-oracle.dto';
+import { OracleService } from './oracle.service';
+
+@Controller('oracle')
+export class OracleController {
+  constructor(private readonly oracleService: OracleService) {}
+
+  @Post('update')
+  async update(@Body() dto: UpdateOracleDto) {
+    // DTO validation is handled by global validation pipe
+    const result = await this.oracleService.updateSnapshot(dto);
+    return { ok: true, ...result };
+  }
+
+  @Get('latest')
+  async latest() {
+    const values = await this.oracleService.getLatest();
+    return { ok: true, values };
+  }
+}

--- a/backend/src/oracle/oracle.module.ts
+++ b/backend/src/oracle/oracle.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { OracleController } from './oracle.controller';
+import { OracleService } from './oracle.service';
+import { OracleSnapshot } from './entities/oracle-snapshot.entity';
+import { OracleLatestPrice } from './entities/oracle-latest.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([OracleSnapshot, OracleLatestPrice])],
+  controllers: [OracleController],
+  providers: [OracleService],
+})
+export class OracleModule {}

--- a/backend/src/oracle/oracle.service.spec.ts
+++ b/backend/src/oracle/oracle.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { OracleService } from './oracle.service';
+
+describe('OracleService', () => {
+  let service: OracleService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [OracleService],
+    }).compile();
+
+    service = module.get<OracleService>(OracleService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/oracle/oracle.service.ts
+++ b/backend/src/oracle/oracle.service.ts
@@ -1,0 +1,92 @@
+import { Injectable, UnauthorizedException, BadRequestException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, DataSource } from 'typeorm';
+import { UpdateOracleDto } from './dto/update-oracle.dto';
+// import { OracleSnapshot } from './entities/oracle-snapshot.entity';
+// import { OracleLatestPrice } from './entities/oracle-latest.entity';
+// import { verifySignature, canonicalizePayload } from './utils/signature.util';
+import * as process from 'process';
+import { OracleSnapshot } from './entities/oracle-snapshot.entity';
+import { OracleLatestPrice } from './entities/oracle-latest.entity';
+import { verifySignature } from './utils/signature.utils';
+
+@Injectable()
+export class OracleService {
+  private readonly oracleSignerAddress: string;
+  private readonly maxClockSkewMs: number;
+
+  constructor(
+    @InjectRepository(OracleSnapshot) private readonly snapshotRepo: Repository<OracleSnapshot>,
+    @InjectRepository(OracleLatestPrice) private readonly latestRepo: Repository<OracleLatestPrice>,
+    private readonly dataSource: DataSource,
+  ) {
+    this.oracleSignerAddress = process.env.ORACLE_SIGNER_ADDRESS; // e.g. 0x...
+    this.maxClockSkewMs = parseInt(process.env.ORACLE_MAX_CLOCK_SKEW_MS || '120000', 10); // default 2min
+  }
+
+  private validateTimestamp(ts: number) {
+    const tMs = ts > 1e12 ? ts : ts * 1000; // accept seconds or ms
+    const now = Date.now();
+    if (Math.abs(now - tMs) > this.maxClockSkewMs) {
+      throw new BadRequestException('timestamp out of allowed skew');
+    }
+    return new Date(tMs);
+  }
+
+  async updateSnapshot(dto: UpdateOracleDto) {
+    // verify signature
+    const recovered = await verifySignature(dto.signature, dto.timestamp, dto.feeds);
+    if (this.oracleSignerAddress && recovered.toLowerCase() !== this.oracleSignerAddress.toLowerCase()) {
+      throw new UnauthorizedException('invalid signature signer');
+    }
+
+    const timestampDate = this.validateTimestamp(dto.timestamp);
+
+    // Transaction: insert snapshot and upsert latest
+    return this.dataSource.transaction(async (manager) => {
+      const snapshot = manager.create(OracleSnapshot, {
+        timestamp: timestampDate,
+        signer: recovered,
+        signature: dto.signature,
+        feeds: dto.feeds,
+      });
+      const savedSnapshot = await manager.save(snapshot);
+
+      // Upsert latest prices (Postgres ON CONFLICT)
+      for (const f of dto.feeds) {
+        // Use query builder to perform upsert
+        await manager
+          .createQueryBuilder()
+          .insert()
+          .into(OracleLatestPrice)
+          .values({
+            pair: f.pair,
+            price: f.price,
+            decimals: f.decimals,
+            timestamp: timestampDate,
+            snapshotId: savedSnapshot.id,
+          })
+          .orUpdate(
+            {
+              conflict_target: ['pair'],
+              overwrite: ['price', 'decimals', 'timestamp', 'snapshotId', 'updatedAt'],
+            },
+            ['pair'],
+          )
+          .execute();
+      }
+
+      return { snapshotId: savedSnapshot.id };
+    });
+  }
+
+  async getLatest() {
+    const latest = await this.latestRepo.find();
+    return latest.map((l) => ({
+      pair: l.pair,
+      price: l.price,
+      decimals: l.decimals,
+      timestamp: l.timestamp,
+    }));
+  }
+}

--- a/backend/src/oracle/utils/signature.utils.ts
+++ b/backend/src/oracle/utils/signature.utils.ts
@@ -1,0 +1,20 @@
+import { ethers } from 'ethers';
+
+/**
+ * Canonicalize payload: sort feeds by pair to ensure deterministic signing.
+ */
+export function canonicalizePayload(timestamp: number, feeds: Array<{ pair: string; price: string; decimals: number }>) {
+  const sorted = [...feeds].sort((a, b) => a.pair.localeCompare(b.pair));
+  return JSON.stringify({ timestamp, feeds: sorted });
+}
+
+/**
+ * Verify a signature produced by ethers' signMessage over canonical payload.
+ * Returns recovered address in checksum format.
+ */
+export async function verifySignature(signature: string, timestamp: number, feeds: Array<{ pair: string; price: string; decimals: number }>) {
+  const message = canonicalizePayload(timestamp, feeds);
+  // ethers verifies a UTF-8 string prefixed with "\x19Ethereum Signed Message:\n" length
+  const recovered = ethers.utils.verifyMessage(message, signature);
+  return ethers.utils.getAddress(recovered);
+}


### PR DESCRIPTION
# Pull Request: Oracle Module Implementation

**Closes:** [#4](https://github.com/StellAIverse/luminarytrade/issues/4)

## Summary
Add an `OracleModule` providing signature-verified off-chain price feeds persisted atomically and a lightweight latest-price read API.

### Exposed Endpoints
* **POST** `/oracle/update`: Accepts a signed canonical feed payload, validates timestamp and signer, stores a snapshot, and upserts latest prices in a single DB transaction.
* **GET** `/oracle/latest`: Returns the latest values for each feed pair.

---

## What I Changed

* **Controller:** Implemented `POST /oracle/update` and `GET /oracle/latest` endpoints.
* **Service:** Added logic for signature verification, timestamp validation, and a DB transaction to atomically persist snapshots while upserting latest prices.
* **DTOs:** Created canonical `Update` payloads and feed DTOs with validation metadata.
* **Entities:** * `oracle_snapshots`: Stores raw feeds and signatures.
    * `oracle_latest_prices`: Stores per-pair latest values for fast retrieval.
* **Utils:** Added canonicalization and signature verification using `ethers`.
* **Tests:** Added skeleton/unit test files (Jest) for signature verification, updates, and retrieval.
* **Module Wiring:** Registered `OracleModule` for Dependency Injection with TypeORM entities.

---

## Files Added (High Level)

| File | Description |
| :--- | :--- |
| `src/oracle/oracle.controller.ts` | API route definitions |
| `src/oracle/oracle.service.ts` | Business logic & validation |
| `src/oracle/oracle.module.ts` | NestJS module registration |
| `src/oracle/dto/update-oracle.dto.ts` | Data transfer objects & validation |
| `src/oracle/entities/oracle-snapshot.entity.ts` | Snapshot history schema |
| `src/oracle/entities/oracle-latest.entity.ts` | Latest price cache schema |
| `src/oracle/utils/signature.util.ts` | Ethers-based crypto utilities |
| `src/oracle/tests/oracle.service.spec.ts` | Unit test suite |