### PR TITLE
refactor(common-utils): replace tuples with type-safe containers

### DIFF
--- a/contracts/common-utils/contract/src/container.rs
+++ b/contracts/common-utils/contract/src/container.rs
@@ -1,0 +1,67 @@
+use serde::{Serialize, Deserialize};
+use std::collections::HashMap;
+
+/// Generic container for typed lists
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TypedContainer<T> {
+    items: Vec<T>,
+}
+
+impl<T> TypedContainer<T> {
+    pub fn new() -> Self {
+        Self { items: Vec::new() }
+    }
+
+    pub fn add(&mut self, item: T) {
+        self.items.push(item);
+    }
+
+    pub fn all(&self) -> &Vec<T> {
+        &self.items
+    }
+
+    pub fn into_vec(self) -> Vec<T> {
+        self.items
+    }
+}
+
+/// Key-value field wrapper for flexible named fields
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NamedFields {
+    fields: HashMap<String, String>,
+}
+
+impl NamedFields {
+    pub fn new() -> Self {
+        Self {
+            fields: HashMap::new(),
+        }
+    }
+
+    pub fn insert<K: Into<String>, V: Into<String>>(&mut self, key: K, value: V) {
+        self.fields.insert(key.into(), value.into());
+    }
+
+    pub fn get(&self, key: &str) -> Option<&String> {
+        self.fields.get(key)
+    }
+
+    pub fn all(&self) -> &HashMap<String, String> {
+        &self.fields
+    }
+}
+
+/// Event wrapper to emit strongly typed events
+pub struct Event<T> {
+    pub topic: String,
+    pub payload: T,
+}
+
+impl<T> Event<T> {
+    pub fn new(topic: &str, payload: T) -> Self {
+        Self {
+            topic: topic.to_string(),
+            payload,
+        }
+    }
+}


### PR DESCRIPTION

- Introduced `TypedContainer<T>` for type-safe collections
- Added `NamedFields` wrapper to replace ad-hoc key-value tuples
- Created `Event<T>` wrapper for strongly typed event emissions
- Updated `fraud-detect` and `agent-metadata` to use typed containers
- Removed all public API tuples to prevent type confusion
- Added builder and helper methods for containers and named fields
- Added serialization/deserialization support with `serde`
- Added unit tests for container operations, named fields, and event wrappers

closes #63 