### PR TITLE
feat(decorator-composition): implement composable decorator system wi…

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -22,6 +22,7 @@ import { PluginsModule } from './plugins/plugins.module';
 import { validate } from './config/config.validation';
 import { AppConfigService } from './config/app-config.service';
 import { MiddlewarePipelineModule } from './middleware-pipeline/middleware-pipeline.module';
+import { DecoratorCompositionModule } from './decorator-composition/decorator-composition.module';
 
 @Module({
   imports: [
@@ -57,6 +58,7 @@ import { MiddlewarePipelineModule } from './middleware-pipeline/middleware-pipel
     AuthModule,
     MaterializedViewsModule,
     MiddlewarePipelineModule,
+    DecoratorCompositionModule,
   ],
   providers: [AppConfigService],
   exports: [AppConfigService],

--- a/backend/src/decorator-composition/__tests__/composition.spec.ts
+++ b/backend/src/decorator-composition/__tests__/composition.spec.ts
@@ -1,0 +1,184 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Controller, Get, INestApplication } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { MetadataRegistryService } from '../metadata-registry.service';
+import { CompositionGuard } from '../guards/composition.guard';
+import { CompositionInterceptor } from '../interceptors/composition.interceptor';
+import { Composable } from '../decorators/composable.decorator';
+import { Cache } from '../decorators/cache.decorator';
+import { Log } from '../decorators/log.decorator';
+import { Transform } from '../decorators/transform.decorator';
+import { Compress } from '../decorators/compress.decorator';
+import { Validate, ValidationSchema } from '../decorators/validate.decorator';
+import {
+  COMPOSABLE_METADATA_KEY,
+  COMPOSITION_STACK_KEY,
+  DECORATOR_PRIORITY,
+} from '../constants';
+
+// ─── Test controller ──────────────────────────────────────────────────────────
+
+const passSchema: ValidationSchema = {
+  validate: () => ({ valid: true }),
+};
+
+@Controller('composition-test')
+class TestController {
+  @Composable()
+  @Cache(300, 'test-ns')
+  @Log('debug')
+  @Get('cached-logged')
+  cachedLogged(): string {
+    return 'hello';
+  }
+
+  @Composable()
+  @Validate(passSchema)
+  @Transform((v: string) => ({ value: v }))
+  @Get('validate-transform')
+  validateTransform(): string {
+    return 'world';
+  }
+
+  @Composable()
+  @Compress()
+  @Get('compressed')
+  compressed(): string {
+    return 'compressed';
+  }
+
+  // Method without @Composable — composition system should not interfere
+  @Get('plain')
+  plain(): string {
+    return 'plain';
+  }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('Decorator Composition — end-to-end', () => {
+  let app: INestApplication;
+  let registry: MetadataRegistryService;
+  let reflector: Reflector;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TestController],
+      providers: [
+        MetadataRegistryService,
+        Reflector,
+        CompositionGuard,
+        CompositionInterceptor,
+      ],
+    }).compile();
+
+    app = module.createNestApplication();
+    app.useGlobalGuards(module.get(CompositionGuard));
+    app.useGlobalInterceptors(module.get(CompositionInterceptor));
+    await app.init();
+
+    registry = module.get(MetadataRegistryService);
+    reflector = module.get(Reflector);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  // ── @Composable ───────────────────────────────────────────────────────────
+
+  it('@Composable marks the method with COMPOSABLE_METADATA_KEY', () => {
+    // NestJS SetMetadata stores metadata on the method function (descriptor.value),
+    // not on the target+propertyKey pair.
+    const meta = Reflect.getMetadata(
+      COMPOSABLE_METADATA_KEY,
+      TestController.prototype.cachedLogged,
+    );
+    expect(meta).toBeDefined();
+    expect(meta.composable).toBe(true);
+  });
+
+  // ── Parallel composition: @Cache + @Log ──────────────────────────────────
+
+  it('stacking @Cache and @Log produces both entries in the registry', () => {
+    const composed = registry.getComposedMetadata('TestController', 'cachedLogged');
+    expect(composed.hasCache).toBe(true);
+    expect(composed.hasLog).toBe(true);
+    expect(composed.hasAuth).toBe(false);
+  });
+
+  it('@Cache entry has correct priority (40)', () => {
+    const composed = registry.getComposedMetadata('TestController', 'cachedLogged');
+    const cacheEntry = composed.stack.find(e => e.type === 'CACHE');
+    expect(cacheEntry?.priority).toBe(DECORATOR_PRIORITY.CACHE);
+    expect(cacheEntry?.options.ttl).toBe(300);
+    expect(cacheEntry?.options.namespace).toBe('test-ns');
+  });
+
+  it('@Log entry has correct priority (50) and level', () => {
+    const composed = registry.getComposedMetadata('TestController', 'cachedLogged');
+    const logEntry = composed.stack.find(e => e.type === 'LOG');
+    expect(logEntry?.priority).toBe(DECORATOR_PRIORITY.LOG);
+    expect(logEntry?.options.level).toBe('debug');
+  });
+
+  it('stack is sorted ascending by priority (CACHE before LOG)', () => {
+    const composed = registry.getComposedMetadata('TestController', 'cachedLogged');
+    const types = composed.stack.map(e => e.type);
+    const cacheIdx = types.indexOf('CACHE');
+    const logIdx = types.indexOf('LOG');
+    expect(cacheIdx).toBeLessThan(logIdx);
+  });
+
+  // ── Serial composition: @Validate → @Transform ───────────────────────────
+
+  it('@Validate and @Transform produce both entries with correct ordering', () => {
+    const composed = registry.getComposedMetadata('TestController', 'validateTransform');
+    expect(composed.hasValidation).toBe(true);
+    expect(composed.hasTransform).toBe(true);
+
+    const types = composed.stack.map(e => e.type);
+    expect(types.indexOf('VALIDATE')).toBeLessThan(types.indexOf('TRANSFORM'));
+  });
+
+  it('@Transform entry stores the mapper function', () => {
+    const composed = registry.getComposedMetadata('TestController', 'validateTransform');
+    const transformEntry = composed.stack.find(e => e.type === 'TRANSFORM');
+    expect(typeof transformEntry?.options.mapper).toBe('function');
+    expect(transformEntry?.options.mapper('test')).toEqual({ value: 'test' });
+  });
+
+  // ── @Compress ─────────────────────────────────────────────────────────────
+
+  it('@Compress produces a COMPRESS entry with priority 70', () => {
+    const composed = registry.getComposedMetadata('TestController', 'compressed');
+    expect(composed.hasCompress).toBe(true);
+    const compressEntry = composed.stack.find(e => e.type === 'COMPRESS');
+    expect(compressEntry?.priority).toBe(DECORATOR_PRIORITY.COMPRESS);
+    expect(compressEntry?.options.compress).toBe(true);
+  });
+
+  // ── Non-composable method ─────────────────────────────────────────────────
+
+  it('plain method has no COMPOSABLE_METADATA_KEY', () => {
+    const meta = Reflect.getMetadata(
+      COMPOSABLE_METADATA_KEY,
+      TestController.prototype.plain,
+    );
+    expect(meta).toBeUndefined();
+  });
+
+  it('plain method has an empty registry entry', () => {
+    const composed = registry.getComposedMetadata('TestController', 'plain');
+    expect(composed.stack).toHaveLength(0);
+  });
+
+  // ── COMPOSITION_STACK_KEY on prototype ────────────────────────────────────
+
+  it('COMPOSITION_STACK_KEY is written to the prototype for Reflector access', () => {
+    const proto = TestController.prototype;
+    const stack = Reflect.getMetadata(COMPOSITION_STACK_KEY, proto, 'cachedLogged');
+    expect(Array.isArray(stack)).toBe(true);
+    expect(stack.length).toBeGreaterThan(0);
+  });
+});

--- a/backend/src/decorator-composition/__tests__/error-scenarios.spec.ts
+++ b/backend/src/decorator-composition/__tests__/error-scenarios.spec.ts
@@ -1,0 +1,192 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  Controller,
+  Get,
+  Post,
+  INestApplication,
+  HttpStatus,
+} from '@nestjs/common';
+import * as request from 'supertest';
+import { Reflector } from '@nestjs/core';
+import { MetadataRegistryService } from '../metadata-registry.service';
+import { CompositionGuard } from '../guards/composition.guard';
+import { CompositionInterceptor } from '../interceptors/composition.interceptor';
+import { Composable } from '../decorators/composable.decorator';
+import { Validate, ValidationSchema } from '../decorators/validate.decorator';
+import { Transform } from '../decorators/transform.decorator';
+import { Cache } from '../decorators/cache.decorator';
+import { Log } from '../decorators/log.decorator';
+
+// ─── Test schema helpers ──────────────────────────────────────────────────────
+
+const throwingSchema: ValidationSchema = {
+  validate(_data: unknown): { valid: boolean; errors?: string[] } {
+    throw new Error('Schema internal error');
+  },
+};
+
+const failSchema: ValidationSchema = {
+  validate: () => ({ valid: false, errors: ['bad input'] }),
+};
+
+// ─── Test controller ──────────────────────────────────────────────────────────
+
+@Controller('error-test')
+class ErrorTestController {
+  /** @Validate schema throws internally */
+  @Composable()
+  @Validate(throwingSchema)
+  @Post('schema-throws')
+  schemaThrows(): object {
+    return { reached: true };
+  }
+
+  /** @Validate fails → 400 */
+  @Composable()
+  @Validate(failSchema)
+  @Post('validate-fail')
+  validateFail(): object {
+    return { reached: true };
+  }
+
+  /** @Transform mapper throws */
+  @Composable()
+  @Transform((_v: any) => {
+    throw new Error('Mapper error');
+  })
+  @Get('transform-throws')
+  transformThrows(): object {
+    return { data: 'original' };
+  }
+
+  /** @Cache duplicate → last-wins merge survives */
+  @Composable()
+  @Cache(60)
+  @Cache(300)
+  @Get('dual-cache')
+  dualCache(): object {
+    return { ttl: 'varies' };
+  }
+
+  /** @Log duplicate → merge strategy */
+  @Composable()
+  @Log('debug')
+  @Log('warn')
+  @Get('dual-log')
+  dualLog(): object {
+    return { logged: true };
+  }
+
+  /** No @Composable — system should pass through transparently */
+  @Get('no-composable')
+  noComposable(): object {
+    return { plain: true };
+  }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('Decorator Composition — error scenarios', () => {
+  let app: INestApplication;
+  let registry: MetadataRegistryService;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ErrorTestController],
+      providers: [
+        MetadataRegistryService,
+        Reflector,
+        CompositionGuard,
+        CompositionInterceptor,
+      ],
+    }).compile();
+
+    app = module.createNestApplication();
+    app.useGlobalGuards(module.get(CompositionGuard));
+    app.useGlobalInterceptors(module.get(CompositionInterceptor));
+    await app.init();
+
+    registry = module.get(MetadataRegistryService);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  // ── Schema throws internally ───────────────────────────────────────────────
+
+  it('schema.validate() that throws internally propagates as 500', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/error-test/schema-throws')
+      .send({})
+      .expect(HttpStatus.INTERNAL_SERVER_ERROR);
+
+    expect(res.body).toBeDefined();
+  });
+
+  // ── @Validate fails → 400 ─────────────────────────────────────────────────
+
+  it('@Validate failure returns 400 BadRequestException', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/error-test/validate-fail')
+      .send({})
+      .expect(HttpStatus.BAD_REQUEST);
+
+    expect(res.body.message).toBe('Validation failed');
+    expect(res.body.errors).toEqual(['bad input']);
+  });
+
+  // ── @Transform mapper throws ───────────────────────────────────────────────
+
+  it('@Transform mapper that throws propagates through RxJS pipeline as 500', async () => {
+    await request(app.getHttpServer())
+      .get('/error-test/transform-throws')
+      .expect(HttpStatus.INTERNAL_SERVER_ERROR);
+  });
+
+  // ── Duplicate @Cache → last-wins ──────────────────────────────────────────
+
+  it('duplicate @Cache → last-wins: only one CACHE entry remains', () => {
+    const composed = registry.getComposedMetadata('ErrorTestController', 'dualCache');
+    const cacheEntries = composed.stack.filter(e => e.type === 'CACHE');
+    expect(cacheEntries).toHaveLength(1);
+    // TypeScript applies decorators bottom-to-top, so @Cache(300) runs first
+    // and @Cache(60) runs last → last-wins means @Cache(60) survives.
+    expect(cacheEntries[0].options.ttl).toBe(60);
+  });
+
+  // ── Duplicate @Log → merge ────────────────────────────────────────────────
+
+  it('duplicate @Log → merge strategy: options are merged (last level wins within merge)', () => {
+    const composed = registry.getComposedMetadata('ErrorTestController', 'dualLog');
+    const logEntries = composed.stack.filter(e => e.type === 'LOG');
+    expect(logEntries).toHaveLength(1);
+    // TypeScript applies decorators bottom-to-top: @Log('warn') runs first, @Log('debug') last.
+    // merge strategy: shallow merge → last 'level' key wins: 'debug'.
+    expect(logEntries[0].options.level).toBe('debug');
+  });
+
+  // ── Route without @Composable passes through ───────────────────────────────
+
+  it('route without @Composable returns 200 unaffected', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/error-test/no-composable')
+      .expect(HttpStatus.OK);
+
+    expect(res.body.plain).toBe(true);
+  });
+
+  it('route without @Composable has no registry entry', () => {
+    const composed = registry.getComposedMetadata('ErrorTestController', 'noComposable');
+    expect(composed.stack).toHaveLength(0);
+  });
+
+  // ── CompositionGuard returns true when COMPOSABLE_METADATA_KEY absent ──────
+
+  it('MetadataRegistryService returns empty metadata for unknown handler', () => {
+    const composed = registry.getComposedMetadata('NonExistent', 'nonExistent');
+    expect(composed.stack).toHaveLength(0);
+    expect(composed.hasAuth).toBe(false);
+    expect(composed.hasCache).toBe(false);
+  });
+});

--- a/backend/src/decorator-composition/__tests__/execution-order.spec.ts
+++ b/backend/src/decorator-composition/__tests__/execution-order.spec.ts
@@ -1,0 +1,192 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  Controller,
+  Get,
+  Post,
+  INestApplication,
+  HttpStatus,
+} from '@nestjs/common';
+import * as request from 'supertest';
+import { Reflector } from '@nestjs/core';
+import { MetadataRegistryService } from '../metadata-registry.service';
+import { CompositionGuard } from '../guards/composition.guard';
+import { CompositionInterceptor } from '../interceptors/composition.interceptor';
+import { Composable } from '../decorators/composable.decorator';
+import { Validate, ValidationSchema } from '../decorators/validate.decorator';
+import { Transform } from '../decorators/transform.decorator';
+import { Log } from '../decorators/log.decorator';
+import { Compress } from '../decorators/compress.decorator';
+import { DECORATOR_PRIORITY } from '../constants';
+
+// ─── Schemas ─────────────────────────────────────────────────────────────────
+
+const alwaysPass: ValidationSchema = {
+  validate: () => ({ valid: true }),
+};
+
+const alwaysFail: ValidationSchema = {
+  validate: () => ({ valid: false, errors: ['field is required'] }),
+};
+
+// ─── Test controller ──────────────────────────────────────────────────────────
+
+let handlerCallCount = 0;
+
+@Controller('order-test')
+class OrderTestController {
+  /** Validate pass → handler should execute */
+  @Composable()
+  @Validate(alwaysPass)
+  @Post('validate-pass')
+  validatePass(): object {
+    handlerCallCount++;
+    return { ok: true };
+  }
+
+  /** Validate fail → handler should NOT execute */
+  @Composable()
+  @Validate(alwaysFail)
+  @Post('validate-fail')
+  validateFail(): object {
+    handlerCallCount++;
+    return { ok: true };
+  }
+
+  /** Transform wraps the handler response */
+  @Composable()
+  @Transform((v: any) => ({ wrapped: v }))
+  @Get('transform')
+  transformResult(): object {
+    return { original: true };
+  }
+
+  /** Compress sets the header */
+  @Composable()
+  @Compress()
+  @Get('compress')
+  compressResult(): object {
+    return { data: 'compressed' };
+  }
+
+  /** Log decorator wraps async handler */
+  @Composable()
+  @Log('debug')
+  @Get('logged')
+  async loggedAsync(): Promise<object> {
+    return { logged: true };
+  }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('Decorator Composition — execution order', () => {
+  let app: INestApplication;
+  let registry: MetadataRegistryService;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [OrderTestController],
+      providers: [
+        MetadataRegistryService,
+        Reflector,
+        CompositionGuard,
+        CompositionInterceptor,
+      ],
+    }).compile();
+
+    app = module.createNestApplication();
+    app.useGlobalGuards(module.get(CompositionGuard));
+    app.useGlobalInterceptors(module.get(CompositionInterceptor));
+    await app.init();
+
+    registry = module.get(MetadataRegistryService);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    handlerCallCount = 0;
+  });
+
+  // ── Priority values ────────────────────────────────────────────────────────
+
+  it('DECORATOR_PRIORITY is monotonically increasing in canonical order', () => {
+    const order = [
+      DECORATOR_PRIORITY.AUTH,
+      DECORATOR_PRIORITY.RATE_LIMIT,
+      DECORATOR_PRIORITY.VALIDATE,
+      DECORATOR_PRIORITY.CACHE,
+      DECORATOR_PRIORITY.LOG,
+      DECORATOR_PRIORITY.TRANSFORM,
+      DECORATOR_PRIORITY.COMPRESS,
+    ];
+    for (let i = 1; i < order.length; i++) {
+      expect(order[i]).toBeGreaterThan(order[i - 1]);
+    }
+  });
+
+  it('sorted stack has priorities in strictly ascending order', () => {
+    const composed = registry.getComposedMetadata('OrderTestController', 'validatePass');
+    for (let i = 1; i < composed.stack.length; i++) {
+      expect(composed.stack[i].priority).toBeGreaterThan(composed.stack[i - 1].priority);
+    }
+  });
+
+  // ── VALIDATE before handler ───────────────────────────────────────────────
+
+  it('@Validate(pass) allows handler to execute → 201', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/order-test/validate-pass')
+      .send({ any: 'data' })
+      .expect(HttpStatus.CREATED);
+
+    expect(res.body.ok).toBe(true);
+    expect(handlerCallCount).toBe(1);
+  });
+
+  it('@Validate(fail) stops execution → 400 before handler runs', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/order-test/validate-fail')
+      .send({ any: 'data' })
+      .expect(HttpStatus.BAD_REQUEST);
+
+    expect(res.body.message).toBe('Validation failed');
+    expect(res.body.errors).toEqual(['field is required']);
+    // Handler must NOT have been called
+    expect(handlerCallCount).toBe(0);
+  });
+
+  // ── TRANSFORM after handler ───────────────────────────────────────────────
+
+  it('@Transform mapper is applied to the handler response', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/order-test/transform')
+      .expect(HttpStatus.OK);
+
+    // CompositionInterceptor wraps the response with { wrapped: ... }
+    expect(res.body.wrapped).toBeDefined();
+    expect(res.body.wrapped.original).toBe(true);
+  });
+
+  // ── COMPRESS header ───────────────────────────────────────────────────────
+
+  it('@Compress sets X-Composition-Compress response header', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/order-test/compress')
+      .expect(HttpStatus.OK);
+
+    expect(res.headers['x-composition-compress']).toBe('true');
+  });
+
+  // ── @Log wraps async handlers ─────────────────────────────────────────────
+
+  it('@Log decorator correctly wraps an async handler', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/order-test/logged')
+      .expect(HttpStatus.OK);
+
+    expect(res.body.logged).toBe(true);
+  });
+});

--- a/backend/src/decorator-composition/__tests__/metadata-registry.spec.ts
+++ b/backend/src/decorator-composition/__tests__/metadata-registry.spec.ts
@@ -1,0 +1,165 @@
+import { MetadataRegistryService, bufferDecoratorEntry } from '../metadata-registry.service';
+import { DecoratorEntry } from '../interfaces/composition.interface';
+import { DECORATOR_PRIORITY } from '../constants';
+
+// Helper to build a DecoratorEntry quickly
+function entry(
+  type: DecoratorEntry['type'],
+  options: Record<string, any> = {},
+): DecoratorEntry {
+  return { type, priority: DECORATOR_PRIORITY[type], options };
+}
+
+describe('MetadataRegistryService', () => {
+  let registry: MetadataRegistryService;
+
+  beforeEach(() => {
+    registry = new MetadataRegistryService();
+    registry.clear();
+  });
+
+  // ── push / getComposedMetadata ─────────────────────────────────────────────
+
+  it('stores and retrieves a single entry', () => {
+    registry.push('MyCtrl', 'myMethod', entry('AUTH', { roles: ['admin'] }));
+    const composed = registry.getComposedMetadata('MyCtrl', 'myMethod');
+    expect(composed.stack).toHaveLength(1);
+    expect(composed.stack[0].type).toBe('AUTH');
+    expect(composed.hasAuth).toBe(true);
+  });
+
+  it('returns empty ComposedMethodMetadata for unknown method', () => {
+    const composed = registry.getComposedMetadata('Unknown', 'unknown');
+    expect(composed.stack).toHaveLength(0);
+    expect(composed.hasAuth).toBe(false);
+    expect(composed.hasCache).toBe(false);
+    expect(composed.hasValidation).toBe(false);
+    expect(composed.hasRateLimit).toBe(false);
+    expect(composed.hasLog).toBe(false);
+    expect(composed.hasTransform).toBe(false);
+    expect(composed.hasCompress).toBe(false);
+  });
+
+  // ── Sorting ───────────────────────────────────────────────────────────────
+
+  it('sorts entries ascending by priority', () => {
+    // Push in reverse priority order
+    registry.push('C', 'm', entry('TRANSFORM'));
+    registry.push('C', 'm', entry('VALIDATE'));
+    registry.push('C', 'm', entry('AUTH'));
+
+    const composed = registry.getComposedMetadata('C', 'm');
+    const types = composed.stack.map(e => e.type);
+    expect(types).toEqual(['AUTH', 'VALIDATE', 'TRANSFORM']);
+  });
+
+  // ── Boolean flags ─────────────────────────────────────────────────────────
+
+  it('sets all boolean flags correctly for a full stack', () => {
+    registry.push('C', 'm', entry('AUTH'));
+    registry.push('C', 'm', entry('RATE_LIMIT'));
+    registry.push('C', 'm', entry('VALIDATE'));
+    registry.push('C', 'm', entry('CACHE'));
+    registry.push('C', 'm', entry('LOG'));
+    registry.push('C', 'm', entry('TRANSFORM'));
+    registry.push('C', 'm', entry('COMPRESS'));
+
+    const composed = registry.getComposedMetadata('C', 'm');
+    expect(composed.hasAuth).toBe(true);
+    expect(composed.hasRateLimit).toBe(true);
+    expect(composed.hasValidation).toBe(true);
+    expect(composed.hasCache).toBe(true);
+    expect(composed.hasLog).toBe(true);
+    expect(composed.hasTransform).toBe(true);
+    expect(composed.hasCompress).toBe(true);
+  });
+
+  // ── Merge strategies ──────────────────────────────────────────────────────
+
+  it('applies last-wins merge for CACHE (duplicate entries)', () => {
+    registry.push('C', 'm', entry('CACHE', { ttl: 60 }));
+    registry.push('C', 'm', entry('CACHE', { ttl: 300, namespace: 'orders' }));
+
+    const composed = registry.getComposedMetadata('C', 'm');
+    // last-wins → the second entry wins
+    expect(composed.stack).toHaveLength(1);
+    expect(composed.stack[0].options.ttl).toBe(300);
+    expect(composed.stack[0].options.namespace).toBe('orders');
+  });
+
+  it('applies last-wins merge for AUTH (duplicate entries)', () => {
+    registry.push('C', 'm', entry('AUTH', { roles: ['user'] }));
+    registry.push('C', 'm', entry('AUTH', { roles: ['admin'] }));
+
+    const composed = registry.getComposedMetadata('C', 'm');
+    expect(composed.stack).toHaveLength(1);
+    expect(composed.stack[0].options.roles).toEqual(['admin']);
+  });
+
+  it('applies merge strategy for LOG (combines options)', () => {
+    registry.push('C', 'm', entry('LOG', { level: 'debug' }));
+    registry.push('C', 'm', entry('LOG', { level: 'warn' }));
+
+    const composed = registry.getComposedMetadata('C', 'm');
+    // merge strategy: shallow merge → last 'level' wins within the merged object
+    expect(composed.stack).toHaveLength(1);
+    expect(composed.stack[0].options.level).toBe('warn');
+  });
+
+  it('applies last-wins for VALIDATE (duplicate schemas)', () => {
+    const schema1 = { validate: () => ({ valid: true }) };
+    const schema2 = { validate: () => ({ valid: false, errors: ['oops'] }) };
+    registry.push('C', 'm', entry('VALIDATE', { schema: schema1 }));
+    registry.push('C', 'm', entry('VALIDATE', { schema: schema2 }));
+
+    const composed = registry.getComposedMetadata('C', 'm');
+    expect(composed.stack).toHaveLength(1);
+    // last-wins: schema2 survives
+    expect(composed.stack[0].options.schema).toBe(schema2);
+  });
+
+  // ── listAll / clear ───────────────────────────────────────────────────────
+
+  it('listAll returns all registered methods', () => {
+    registry.push('Ctrl', 'methodA', entry('AUTH'));
+    registry.push('Ctrl', 'methodB', entry('CACHE'));
+
+    const all = registry.listAll();
+    expect(Object.keys(all)).toContain('Ctrl.methodA');
+    expect(Object.keys(all)).toContain('Ctrl.methodB');
+  });
+
+  it('clear empties the store', () => {
+    registry.push('C', 'm', entry('AUTH'));
+    registry.clear();
+    const composed = registry.getComposedMetadata('C', 'm');
+    expect(composed.stack).toHaveLength(0);
+  });
+
+  // ── bufferDecoratorEntry ──────────────────────────────────────────────────
+
+  it('entries pushed via bufferDecoratorEntry are drained into a new instance', () => {
+    // bufferDecoratorEntry writes into the module-level PRE_INIT_BUFFER.
+    // A fresh MetadataRegistryService instance drains the buffer in its constructor.
+    bufferDecoratorEntry('BufferCtrl', 'bufferedMethod', entry('LOG', { level: 'verbose' }));
+    const fresh = new MetadataRegistryService();
+    const composed = fresh.getComposedMetadata('BufferCtrl', 'bufferedMethod');
+    // The buffer may contain entries from other test runs; we just assert ours is there
+    expect(composed.hasLog).toBe(true);
+  });
+
+  // ── Isolation between methods ─────────────────────────────────────────────
+
+  it('does not mix metadata between different methods', () => {
+    registry.push('C', 'methodA', entry('AUTH'));
+    registry.push('C', 'methodB', entry('CACHE', { ttl: 60 }));
+
+    const a = registry.getComposedMetadata('C', 'methodA');
+    const b = registry.getComposedMetadata('C', 'methodB');
+
+    expect(a.hasAuth).toBe(true);
+    expect(a.hasCache).toBe(false);
+    expect(b.hasAuth).toBe(false);
+    expect(b.hasCache).toBe(true);
+  });
+});

--- a/backend/src/decorator-composition/constants.ts
+++ b/backend/src/decorator-composition/constants.ts
@@ -1,0 +1,42 @@
+// ─── Metadata Keys ───────────────────────────────────────────────────────────
+
+/** Written by @Composable — gates the guard and interceptor */
+export const COMPOSABLE_METADATA_KEY = 'composition:composable';
+
+/** Reflector-readable stack of DecoratorEntry objects per method */
+export const COMPOSITION_STACK_KEY = 'composition:stack';
+
+/** Metadata key under which the sorted composition order is stored */
+export const COMPOSITION_ORDER_KEY = 'composition:order';
+
+/** Parameter decorator metadata stored per method on the prototype */
+export const PARAM_METADATA_KEY = 'composition:params';
+
+/** Schema stored by @Validate */
+export const VALIDATE_SCHEMA_KEY = 'composition:validate:schema';
+
+/** Flag stored by @Compress */
+export const COMPRESS_METADATA_KEY = 'composition:compress';
+
+/** Mapper function stored by @Transform */
+export const TRANSFORM_MAPPER_KEY = 'composition:transform:mapper';
+
+// ─── Execution Priority ───────────────────────────────────────────────────────
+// Lower number = runs first.
+// AUTH and RATE_LIMIT run in the guard phase (early termination possible).
+// VALIDATE runs in the interceptor phase before the handler.
+// CACHE runs inside the handler descriptor wrapper.
+// LOG wraps the descriptor and measures duration.
+// TRANSFORM and COMPRESS are applied after the handler returns.
+
+export const DECORATOR_PRIORITY = {
+  AUTH: 10,
+  RATE_LIMIT: 20,
+  VALIDATE: 30,
+  CACHE: 40,
+  LOG: 50,
+  TRANSFORM: 60,
+  COMPRESS: 70,
+} as const;
+
+export type DecoratorType = keyof typeof DECORATOR_PRIORITY;

--- a/backend/src/decorator-composition/decorator-composition.module.ts
+++ b/backend/src/decorator-composition/decorator-composition.module.ts
@@ -1,0 +1,34 @@
+import { Global, Module, APP_GUARD, APP_INTERCEPTOR } from '@nestjs/common';
+import { MetadataRegistryService } from './metadata-registry.service';
+import { CompositionGuard } from './guards/composition.guard';
+import { CompositionInterceptor } from './interceptors/composition.interceptor';
+
+/**
+ * DecoratorCompositionModule — global module for the decorator composition system.
+ *
+ * Registers:
+ *  - MetadataRegistryService (exported for injection in other modules)
+ *  - CompositionGuard as APP_GUARD (runs on every request, no-ops when @Composable is absent)
+ *  - CompositionInterceptor as APP_INTERCEPTOR (runs on every request, no-ops when @Composable is absent)
+ *
+ * Import once in AppModule:
+ * @example
+ * @Module({ imports: [DecoratorCompositionModule, ...] })
+ * export class AppModule {}
+ */
+@Global()
+@Module({
+  providers: [
+    MetadataRegistryService,
+    {
+      provide: APP_GUARD,
+      useClass: CompositionGuard,
+    },
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: CompositionInterceptor,
+    },
+  ],
+  exports: [MetadataRegistryService],
+})
+export class DecoratorCompositionModule {}

--- a/backend/src/decorator-composition/decorators/auth.decorator.ts
+++ b/backend/src/decorator-composition/decorators/auth.decorator.ts
@@ -1,0 +1,77 @@
+import { applyDecorators, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { PermissionGuard } from '../../common/guards/permission.guard';
+import { RequirePermission } from '../../common/decorators/require-permission.decorator';
+import { Action } from '../../common/constant/actions.enum';
+import { DECORATOR_PRIORITY, COMPOSITION_STACK_KEY } from '../constants';
+import { bufferDecoratorEntry } from '../metadata-registry.service';
+import { DecoratorEntry } from '../interfaces/composition.interface';
+
+export interface AuthOptions {
+  /** Optional role names (informational — stored in metadata for introspection) */
+  roles?: string[];
+  /** Resource identifier forwarded to RequirePermission */
+  resource?: string;
+  /** Action forwarded to RequirePermission */
+  action?: Action;
+}
+
+/**
+ * @Auth(options) — composable authentication + permission decorator.
+ *
+ * Applies JwtAuthGuard and (optionally) PermissionGuard via applyDecorators,
+ * then registers an AUTH entry in the composition metadata system.
+ *
+ * Execution priority: 10 (runs first, before all other composed phases).
+ * Early termination: if JWT or permission check fails, NestJS guard chain
+ * stops and the interceptor never runs.
+ *
+ * @example
+ * @Composable()
+ * @Auth({ resource: 'profile', action: Action.READ })
+ * @Cache(60)
+ * getProfile() { ... }
+ */
+export const Auth = (options: AuthOptions = {}): MethodDecorator => {
+  return (
+    target: any,
+    propertyKey: string | symbol,
+    descriptor: PropertyDescriptor,
+  ) => {
+    const className = target.constructor.name;
+    const methodName = String(propertyKey);
+
+    const entry: DecoratorEntry = {
+      type: 'AUTH',
+      priority: DECORATOR_PRIORITY.AUTH,
+      options,
+    };
+
+    // Register in pre-init buffer for MetadataRegistryService
+    bufferDecoratorEntry(className, methodName, entry);
+
+    // Also write onto the Reflector-readable stack for runtime introspection
+    const existingStack: DecoratorEntry[] =
+      Reflect.getMetadata(COMPOSITION_STACK_KEY, target, propertyKey) ?? [];
+    Reflect.defineMetadata(
+      COMPOSITION_STACK_KEY,
+      [...existingStack, entry],
+      target,
+      propertyKey,
+    );
+
+    // Compose the real NestJS guards
+    const decoratorsToApply: (MethodDecorator | ClassDecorator)[] = [
+      UseGuards(JwtAuthGuard, PermissionGuard) as MethodDecorator,
+    ];
+
+    if (options.resource && options.action) {
+      decoratorsToApply.push(
+        RequirePermission(options.resource, options.action) as MethodDecorator,
+      );
+    }
+
+    applyDecorators(...decoratorsToApply)(target, propertyKey, descriptor);
+    return descriptor;
+  };
+};

--- a/backend/src/decorator-composition/decorators/cache.decorator.ts
+++ b/backend/src/decorator-composition/decorators/cache.decorator.ts
@@ -1,0 +1,54 @@
+import { DECORATOR_PRIORITY, COMPOSITION_STACK_KEY } from '../constants';
+import { bufferDecoratorEntry } from '../metadata-registry.service';
+import { DecoratorEntry } from '../interfaces/composition.interface';
+import { Cacheable } from '../../cache/decorators/cacheable.decorator';
+
+/**
+ * @Cache(ttl, namespace?) — composable caching decorator.
+ *
+ * Thin convenience wrapper over the existing @Cacheable decorator that
+ * additionally registers a CACHE entry in the composition metadata system.
+ *
+ * Actual caching is handled by the @Cacheable descriptor wrapper; this
+ * decorator does not duplicate that logic.
+ *
+ * Execution priority: 40 (after VALIDATE, before LOG/TRANSFORM).
+ * On a cache hit the handler body is skipped entirely.
+ *
+ * @example
+ * @Composable()
+ * @Cache(300, 'profiles')
+ * @Log()
+ * getProfile(@Param('id') id: string) { ... }
+ */
+export const Cache = (ttl: number, namespace?: string): MethodDecorator => {
+  return (
+    target: any,
+    propertyKey: string | symbol,
+    descriptor: PropertyDescriptor,
+  ) => {
+    const className = target.constructor.name;
+    const methodName = String(propertyKey);
+
+    const entry: DecoratorEntry = {
+      type: 'CACHE',
+      priority: DECORATOR_PRIORITY.CACHE,
+      options: { ttl, namespace },
+    };
+
+    bufferDecoratorEntry(className, methodName, entry);
+
+    const existingStack: DecoratorEntry[] =
+      Reflect.getMetadata(COMPOSITION_STACK_KEY, target, propertyKey) ?? [];
+    Reflect.defineMetadata(
+      COMPOSITION_STACK_KEY,
+      [...existingStack, entry],
+      target,
+      propertyKey,
+    );
+
+    // Delegate to the existing @Cacheable for full caching behaviour
+    Cacheable({ ttl, namespace })(target, propertyKey, descriptor);
+    return descriptor;
+  };
+};

--- a/backend/src/decorator-composition/decorators/composable.decorator.ts
+++ b/backend/src/decorator-composition/decorators/composable.decorator.ts
@@ -1,0 +1,50 @@
+import { SetMetadata } from '@nestjs/common';
+import { COMPOSABLE_METADATA_KEY } from '../constants';
+import { ComposableMetadata } from '../interfaces/composition.interface';
+
+/**
+ * @Composable() — opt-in marker for the decorator composition system.
+ *
+ * The CompositionGuard and CompositionInterceptor short-circuit immediately
+ * for any method/class that does NOT carry this key, so there is zero overhead
+ * on routes that have not opted in.
+ *
+ * Can be applied to a class (opt-in all methods) or to a single method.
+ *
+ * @example
+ * @Composable()
+ * @Controller('users')
+ * export class UsersController { ... }
+ *
+ * @example
+ * @Composable()
+ * @Auth({ roles: ['admin'] })
+ * @Cache(300)
+ * getProfile() { ... }
+ */
+export const Composable = (): MethodDecorator & ClassDecorator => {
+  return (
+    target: any,
+    propertyKey?: string | symbol,
+    descriptor?: PropertyDescriptor,
+  ) => {
+    const metadata: ComposableMetadata = {
+      composable: true,
+      className: target.constructor?.name ?? target.name,
+      methodName: propertyKey ? String(propertyKey) : undefined,
+    };
+
+    if (descriptor) {
+      // Method decorator path
+      SetMetadata(COMPOSABLE_METADATA_KEY, metadata)(
+        target,
+        propertyKey as string,
+        descriptor,
+      );
+      return descriptor;
+    }
+
+    // Class decorator path
+    SetMetadata(COMPOSABLE_METADATA_KEY, metadata)(target);
+  };
+};

--- a/backend/src/decorator-composition/decorators/compress.decorator.ts
+++ b/backend/src/decorator-composition/decorators/compress.decorator.ts
@@ -1,0 +1,56 @@
+import { SetMetadata } from '@nestjs/common';
+import {
+  DECORATOR_PRIORITY,
+  COMPOSITION_STACK_KEY,
+  COMPRESS_METADATA_KEY,
+} from '../constants';
+import { bufferDecoratorEntry } from '../metadata-registry.service';
+import { DecoratorEntry } from '../interfaces/composition.interface';
+
+/**
+ * @Compress() — composable compression hint decorator.
+ *
+ * Stores a flag in metadata that the CompositionInterceptor reads to set an
+ * `X-Composition-Compress: true` response header. Actual body compression is
+ * handled by the Express/Fastify compression middleware configured at the
+ * application level; this decorator signals the intent and participates in
+ * the composition metadata system.
+ *
+ * Execution priority: 70 (last — applied after all other phases).
+ *
+ * @example
+ * @Composable()
+ * @Compress()
+ * @Transform(data => ({ items: data }))
+ * listItems() { ... }
+ */
+export const Compress = (): MethodDecorator => {
+  return (
+    target: any,
+    propertyKey: string | symbol,
+    descriptor: PropertyDescriptor,
+  ) => {
+    const className = target.constructor.name;
+    const methodName = String(propertyKey);
+
+    const entry: DecoratorEntry = {
+      type: 'COMPRESS',
+      priority: DECORATOR_PRIORITY.COMPRESS,
+      options: { compress: true },
+    };
+
+    bufferDecoratorEntry(className, methodName, entry);
+
+    const existingStack: DecoratorEntry[] =
+      Reflect.getMetadata(COMPOSITION_STACK_KEY, target, propertyKey) ?? [];
+    Reflect.defineMetadata(
+      COMPOSITION_STACK_KEY,
+      [...existingStack, entry],
+      target,
+      propertyKey,
+    );
+
+    SetMetadata(COMPRESS_METADATA_KEY, true)(target, propertyKey, descriptor);
+    return descriptor;
+  };
+};

--- a/backend/src/decorator-composition/decorators/log.decorator.ts
+++ b/backend/src/decorator-composition/decorators/log.decorator.ts
@@ -1,0 +1,83 @@
+import { Logger } from '@nestjs/common';
+import { DECORATOR_PRIORITY, COMPOSITION_STACK_KEY } from '../constants';
+import { bufferDecoratorEntry } from '../metadata-registry.service';
+import { DecoratorEntry } from '../interfaces/composition.interface';
+
+export type LogLevel = 'log' | 'debug' | 'verbose' | 'warn' | 'error';
+
+/**
+ * @Log(level?) — composable structured logging decorator.
+ *
+ * Wraps the method descriptor to emit a structured log entry on invocation
+ * and on resolution or rejection, including elapsed time in milliseconds.
+ *
+ * Execution priority: 50 (after CACHE, before TRANSFORM/COMPRESS).
+ *
+ * When two @Log decorators are stacked (e.g. @Log('debug') + @Log('warn')),
+ * the merge strategy is 'merge', so both level values end up in the options
+ * object (last key wins within the merge). The descriptor wrapping applied
+ * here uses the level value supplied at decoration time.
+ *
+ * @example
+ * @Composable()
+ * @Log('debug')
+ * @Cache(120)
+ * getOrders() { ... }
+ */
+export const Log = (level: LogLevel = 'log'): MethodDecorator => {
+  return (
+    target: any,
+    propertyKey: string | symbol,
+    descriptor: PropertyDescriptor,
+  ) => {
+    const className = target.constructor.name;
+    const methodName = String(propertyKey);
+    const logger = new Logger(`${className}.${methodName}`);
+    const original = descriptor.value as (...args: unknown[]) => unknown;
+
+    const entry: DecoratorEntry = {
+      type: 'LOG',
+      priority: DECORATOR_PRIORITY.LOG,
+      options: { level },
+    };
+
+    bufferDecoratorEntry(className, methodName, entry);
+
+    const existingStack: DecoratorEntry[] =
+      Reflect.getMetadata(COMPOSITION_STACK_KEY, target, propertyKey) ?? [];
+    Reflect.defineMetadata(
+      COMPOSITION_STACK_KEY,
+      [...existingStack, entry],
+      target,
+      propertyKey,
+    );
+
+    const wrapper = async function (...args: unknown[]) {
+      const start = Date.now();
+      logger[level](`→ ${methodName}`, { argsCount: args.length });
+      try {
+        const result = await original.apply(this, args);
+        logger[level](`← ${methodName}`, { durationMs: Date.now() - start });
+        return result;
+      } catch (err) {
+        logger.error(`✗ ${methodName}`, {
+          durationMs: Date.now() - start,
+          error: (err as Error).message,
+        });
+        throw err;
+      }
+    };
+
+    // Copy all NestJS/reflect-metadata entries from the original method function
+    // to the wrapper so that route paths, guards, interceptors and other
+    // decorator-stored metadata are not lost when the descriptor is replaced.
+    const metaKeys: any[] = Reflect.getMetadataKeys(original) ?? [];
+    metaKeys.forEach((key: any) => {
+      const meta = Reflect.getMetadata(key, original);
+      Reflect.defineMetadata(key, meta, wrapper);
+    });
+
+    descriptor.value = wrapper;
+    return descriptor;
+  };
+};

--- a/backend/src/decorator-composition/decorators/param.decorator.ts
+++ b/backend/src/decorator-composition/decorators/param.decorator.ts
@@ -1,0 +1,120 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { PARAM_METADATA_KEY } from '../constants';
+import { ParamDecoratorEntry, ParamSource } from '../interfaces/parameter-metadata.interface';
+
+// ─── Internal helper ─────────────────────────────────────────────────────────
+
+function recordParamEntry(
+  target: object,
+  methodName: string,
+  index: number,
+  source: ParamSource,
+  key?: string,
+  extractor?: (req: any) => any,
+): void {
+  const existing: ParamDecoratorEntry[] =
+    Reflect.getMetadata(PARAM_METADATA_KEY, target, methodName) ?? [];
+  existing.push({ index, source, key, extractor });
+  Reflect.defineMetadata(PARAM_METADATA_KEY, existing, target, methodName);
+}
+
+// ─── Composable Parameter Decorators ─────────────────────────────────────────
+
+/**
+ * @Param(key?) — extract a route parameter from req.params.
+ *
+ * Wraps NestJS's own param extraction and stores a ParamDecoratorEntry so
+ * the composition system can introspect parameter metadata at request time.
+ *
+ * @example
+ * getUser(@Param('id') id: string) { ... }
+ */
+export const Param = (key?: string): ParameterDecorator => {
+  const factory = createParamDecorator(
+    (data: string | undefined, ctx: ExecutionContext) => {
+      const req = ctx.switchToHttp().getRequest();
+      return data ? req.params?.[data] : req.params;
+    },
+  );
+
+  const nestDecorator = factory(key);
+
+  return (target: object, propertyKey: string | symbol, parameterIndex: number) => {
+    recordParamEntry(target, String(propertyKey), parameterIndex, 'param', key);
+    nestDecorator(target, propertyKey, parameterIndex);
+  };
+};
+
+/**
+ * @Query(key?) — extract a query-string parameter from req.query.
+ *
+ * @example
+ * search(@Query('q') q: string) { ... }
+ */
+export const Query = (key?: string): ParameterDecorator => {
+  const factory = createParamDecorator(
+    (data: string | undefined, ctx: ExecutionContext) => {
+      const req = ctx.switchToHttp().getRequest();
+      return data ? req.query?.[data] : req.query;
+    },
+  );
+
+  const nestDecorator = factory(key);
+
+  return (target: object, propertyKey: string | symbol, parameterIndex: number) => {
+    recordParamEntry(target, String(propertyKey), parameterIndex, 'query', key);
+    nestDecorator(target, propertyKey, parameterIndex);
+  };
+};
+
+/**
+ * @Body(key?) — extract the request body or a field from it.
+ *
+ * @example
+ * create(@Body() dto: CreateOrderDto) { ... }
+ * create(@Body('amount') amount: number) { ... }
+ */
+export const Body = (key?: string): ParameterDecorator => {
+  const factory = createParamDecorator(
+    (data: string | undefined, ctx: ExecutionContext) => {
+      const req = ctx.switchToHttp().getRequest();
+      return data ? req.body?.[data] : req.body;
+    },
+  );
+
+  const nestDecorator = factory(key);
+
+  return (target: object, propertyKey: string | symbol, parameterIndex: number) => {
+    recordParamEntry(target, String(propertyKey), parameterIndex, 'body', key);
+    nestDecorator(target, propertyKey, parameterIndex);
+  };
+};
+
+/**
+ * @CustomParam(extractor) — extract an arbitrary value from the request using
+ * a custom extractor function.
+ *
+ * @example
+ * getUser(@CustomParam(req => req.user.id) userId: string) { ... }
+ */
+export const CustomParam = (extractor: (req: any) => any): ParameterDecorator => {
+  const factory = createParamDecorator(
+    (_data: unknown, ctx: ExecutionContext) => {
+      return extractor(ctx.switchToHttp().getRequest());
+    },
+  );
+
+  const nestDecorator = factory();
+
+  return (target: object, propertyKey: string | symbol, parameterIndex: number) => {
+    recordParamEntry(
+      target,
+      String(propertyKey),
+      parameterIndex,
+      'custom',
+      undefined,
+      extractor,
+    );
+    nestDecorator(target, propertyKey, parameterIndex);
+  };
+};

--- a/backend/src/decorator-composition/decorators/rate-limit.decorator.ts
+++ b/backend/src/decorator-composition/decorators/rate-limit.decorator.ts
@@ -1,0 +1,66 @@
+import { DECORATOR_PRIORITY, COMPOSITION_STACK_KEY } from '../constants';
+import { bufferDecoratorEntry } from '../metadata-registry.service';
+import { DecoratorEntry } from '../interfaces/composition.interface';
+import {
+  RateLimit as OriginalRateLimit,
+} from '../../rate-limiting/decorators/rate-limit.decorator';
+import { RateLimitStrategy } from '../../rate-limiting/interfaces/rate-limiter.interface';
+
+export interface ComposedRateLimitOptions {
+  requests: number;
+  window: number;
+  strategy: RateLimitStrategy;
+}
+
+/**
+ * @ComposedRateLimit(requests, window, strategy?) — composable rate-limiting.
+ *
+ * Thin wrapper over the existing @RateLimit decorator that additionally
+ * registers a RATE_LIMIT entry in the composition metadata system.
+ *
+ * Execution priority: 20 (runs after AUTH, before VALIDATE).
+ * Early termination: if the rate limit is exceeded, the guard chain stops.
+ *
+ * Re-exported from the index barrel as `RateLimit` to avoid import confusion.
+ *
+ * @example
+ * @Composable()
+ * @Auth({ resource: 'orders', action: Action.CREATE })
+ * @ComposedRateLimit(100, 60_000)
+ * createOrder(@Body() dto: CreateOrderDto) { ... }
+ */
+export const ComposedRateLimit = (
+  requests: number,
+  window: number,
+  strategy: RateLimitStrategy = RateLimitStrategy.SLIDING_WINDOW,
+): MethodDecorator => {
+  return (
+    target: any,
+    propertyKey: string | symbol,
+    descriptor: PropertyDescriptor,
+  ) => {
+    const className = target.constructor.name;
+    const methodName = String(propertyKey);
+
+    const entry: DecoratorEntry = {
+      type: 'RATE_LIMIT',
+      priority: DECORATOR_PRIORITY.RATE_LIMIT,
+      options: { requests, window, strategy },
+    };
+
+    bufferDecoratorEntry(className, methodName, entry);
+
+    const existingStack: DecoratorEntry[] =
+      Reflect.getMetadata(COMPOSITION_STACK_KEY, target, propertyKey) ?? [];
+    Reflect.defineMetadata(
+      COMPOSITION_STACK_KEY,
+      [...existingStack, entry],
+      target,
+      propertyKey,
+    );
+
+    // Delegate actual rate-limit logic to the existing decorator + guard
+    OriginalRateLimit(requests, window, strategy)(target, propertyKey, descriptor);
+    return descriptor;
+  };
+};

--- a/backend/src/decorator-composition/decorators/transform.decorator.ts
+++ b/backend/src/decorator-composition/decorators/transform.decorator.ts
@@ -1,0 +1,57 @@
+import { SetMetadata } from '@nestjs/common';
+import {
+  DECORATOR_PRIORITY,
+  COMPOSITION_STACK_KEY,
+  TRANSFORM_MAPPER_KEY,
+} from '../constants';
+import { bufferDecoratorEntry } from '../metadata-registry.service';
+import { DecoratorEntry } from '../interfaces/composition.interface';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type OutputMapper<T = any, R = any> = (output: T) => R;
+
+/**
+ * @Transform(mapper) — composable output transformation decorator.
+ *
+ * Stores a mapping function in metadata. The CompositionInterceptor applies
+ * it via RxJS `pipe(map(mapper))` after the handler returns, transforming the
+ * response before it is serialised and sent to the client.
+ *
+ * Execution priority: 60 (after LOG, before COMPRESS).
+ * Merge strategy: last-wins — the innermost @Transform mapper takes effect.
+ *
+ * @example
+ * @Composable()
+ * @Transform(items => ({ data: items, count: items.length }))
+ * listOrders() { ... }
+ */
+export const Transform = (mapper: OutputMapper): MethodDecorator => {
+  return (
+    target: any,
+    propertyKey: string | symbol,
+    descriptor: PropertyDescriptor,
+  ) => {
+    const className = target.constructor.name;
+    const methodName = String(propertyKey);
+
+    const entry: DecoratorEntry = {
+      type: 'TRANSFORM',
+      priority: DECORATOR_PRIORITY.TRANSFORM,
+      options: { mapper },
+    };
+
+    bufferDecoratorEntry(className, methodName, entry);
+
+    const existingStack: DecoratorEntry[] =
+      Reflect.getMetadata(COMPOSITION_STACK_KEY, target, propertyKey) ?? [];
+    Reflect.defineMetadata(
+      COMPOSITION_STACK_KEY,
+      [...existingStack, entry],
+      target,
+      propertyKey,
+    );
+
+    SetMetadata(TRANSFORM_MAPPER_KEY, mapper)(target, propertyKey, descriptor);
+    return descriptor;
+  };
+};

--- a/backend/src/decorator-composition/decorators/validate.decorator.ts
+++ b/backend/src/decorator-composition/decorators/validate.decorator.ts
@@ -1,0 +1,70 @@
+import { SetMetadata } from '@nestjs/common';
+import {
+  DECORATOR_PRIORITY,
+  COMPOSITION_STACK_KEY,
+  VALIDATE_SCHEMA_KEY,
+} from '../constants';
+import { bufferDecoratorEntry } from '../metadata-registry.service';
+import { DecoratorEntry } from '../interfaces/composition.interface';
+
+/**
+ * Minimal validation schema interface — duck-typed so it works with Joi, Zod,
+ * class-validator wrappers, or any custom validator.
+ */
+export interface ValidationSchema {
+  validate(data: unknown): { valid: boolean; errors?: string[] };
+}
+
+/**
+ * @Validate(schema) — composable request-body validation.
+ *
+ * Stores the schema in NestJS metadata. The CompositionInterceptor reads it
+ * and calls schema.validate(req.body) BEFORE the handler executes.
+ * If validation fails, a BadRequestException is thrown immediately.
+ *
+ * Execution priority: 30 (after AUTH/RATE_LIMIT, before CACHE/LOG/TRANSFORM).
+ *
+ * @example
+ * const createOrderSchema: ValidationSchema = {
+ *   validate: (data: any) => ({
+ *     valid: !!data?.amount && data.amount > 0,
+ *     errors: data?.amount ? [] : ['amount must be positive'],
+ *   }),
+ * };
+ *
+ * @Composable()
+ * @Auth({ resource: 'orders', action: Action.CREATE })
+ * @Validate(createOrderSchema)
+ * createOrder(@Body() dto: CreateOrderDto) { ... }
+ */
+export const Validate = (schema: ValidationSchema): MethodDecorator => {
+  return (
+    target: any,
+    propertyKey: string | symbol,
+    descriptor: PropertyDescriptor,
+  ) => {
+    const className = target.constructor.name;
+    const methodName = String(propertyKey);
+
+    const entry: DecoratorEntry = {
+      type: 'VALIDATE',
+      priority: DECORATOR_PRIORITY.VALIDATE,
+      options: { schema },
+    };
+
+    bufferDecoratorEntry(className, methodName, entry);
+
+    const existingStack: DecoratorEntry[] =
+      Reflect.getMetadata(COMPOSITION_STACK_KEY, target, propertyKey) ?? [];
+    Reflect.defineMetadata(
+      COMPOSITION_STACK_KEY,
+      [...existingStack, entry],
+      target,
+      propertyKey,
+    );
+
+    // Store schema for Reflector access in the interceptor
+    SetMetadata(VALIDATE_SCHEMA_KEY, schema)(target, propertyKey, descriptor);
+    return descriptor;
+  };
+};

--- a/backend/src/decorator-composition/guards/composition.guard.ts
+++ b/backend/src/decorator-composition/guards/composition.guard.ts
@@ -1,0 +1,118 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { COMPOSABLE_METADATA_KEY, DECORATOR_PRIORITY } from '../constants';
+import { MetadataRegistryService } from '../metadata-registry.service';
+
+/**
+ * CompositionGuard — global guard for the decorator composition system.
+ *
+ * Responsibilities:
+ *  1. Short-circuit immediately (return true) for any route that has not been
+ *     marked @Composable(), so there is zero overhead on non-participating routes.
+ *  2. Validate decorator ordering integrity at request time: AUTH must have a
+ *     lower priority number than VALIDATE, which must be lower than TRANSFORM, etc.
+ *     This catches misconfiguration early rather than silently producing wrong
+ *     behaviour.
+ *
+ * Note: AUTH enforcement (JwtAuthGuard / PermissionGuard) and RATE_LIMIT
+ * enforcement (RateLimitGuard) are applied directly by @Auth and
+ * @ComposedRateLimit via UseGuards — this guard does not duplicate them.
+ * It runs in the same guard phase and provides compositional integrity checks.
+ *
+ * Registered as APP_GUARD in DecoratorCompositionModule.
+ */
+@Injectable()
+export class CompositionGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly registry: MetadataRegistryService,
+  ) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const isComposable = this.reflector.getAllAndOverride(
+      COMPOSABLE_METADATA_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
+    // Not opted in → pass through immediately
+    if (!isComposable) return true;
+
+    const handler = context.getHandler();
+    const controller = context.getClass();
+
+    const composed = this.registry.getComposedMetadata(
+      controller.name,
+      handler.name,
+    );
+
+    // ── Ordering integrity checks ─────────────────────────────────────────
+    // Verify that the declared priority ordering matches the canonical table.
+    // This catches cases where a custom decorator was registered with a wrong
+    // priority value.
+
+    const byType = new Map(composed.stack.map(e => [e.type, e.priority]));
+
+    const authPriority = byType.get('AUTH');
+    const rateLimitPriority = byType.get('RATE_LIMIT');
+    const validatePriority = byType.get('VALIDATE');
+    const cachePriority = byType.get('CACHE');
+    const transformPriority = byType.get('TRANSFORM');
+    const compressPriority = byType.get('COMPRESS');
+
+    if (authPriority !== undefined && validatePriority !== undefined) {
+      if (authPriority >= validatePriority) {
+        throw new InternalServerErrorException(
+          `Composition ordering violation on ${controller.name}.${handler.name}: ` +
+          `AUTH priority (${authPriority}) must be less than VALIDATE priority (${validatePriority}).`,
+        );
+      }
+    }
+
+    if (rateLimitPriority !== undefined && validatePriority !== undefined) {
+      if (rateLimitPriority >= validatePriority) {
+        throw new InternalServerErrorException(
+          `Composition ordering violation on ${controller.name}.${handler.name}: ` +
+          `RATE_LIMIT priority (${rateLimitPriority}) must be less than VALIDATE priority (${validatePriority}).`,
+        );
+      }
+    }
+
+    if (validatePriority !== undefined && cachePriority !== undefined) {
+      if (validatePriority >= cachePriority) {
+        throw new InternalServerErrorException(
+          `Composition ordering violation on ${controller.name}.${handler.name}: ` +
+          `VALIDATE priority (${validatePriority}) must be less than CACHE priority (${cachePriority}).`,
+        );
+      }
+    }
+
+    if (
+      transformPriority !== undefined &&
+      compressPriority !== undefined &&
+      transformPriority >= compressPriority
+    ) {
+      throw new InternalServerErrorException(
+        `Composition ordering violation on ${controller.name}.${handler.name}: ` +
+        `TRANSFORM priority (${transformPriority}) must be less than COMPRESS priority (${compressPriority}).`,
+      );
+    }
+
+    // Only verify canonical priorities match expected values
+    for (const entry of composed.stack) {
+      const expected = DECORATOR_PRIORITY[entry.type];
+      if (expected !== undefined && entry.priority !== expected) {
+        throw new InternalServerErrorException(
+          `Composition priority mismatch on ${controller.name}.${handler.name}: ` +
+          `decorator type ${entry.type} has priority ${entry.priority} but expected ${expected}.`,
+        );
+      }
+    }
+
+    return true;
+  }
+}

--- a/backend/src/decorator-composition/index.ts
+++ b/backend/src/decorator-composition/index.ts
@@ -1,0 +1,70 @@
+// ─── Module ──────────────────────────────────────────────────────────────────
+export { DecoratorCompositionModule } from './decorator-composition.module';
+
+// ─── Core Service ────────────────────────────────────────────────────────────
+export {
+  MetadataRegistryService,
+  bufferDecoratorEntry,
+} from './metadata-registry.service';
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+export {
+  COMPOSABLE_METADATA_KEY,
+  COMPOSITION_STACK_KEY,
+  COMPOSITION_ORDER_KEY,
+  PARAM_METADATA_KEY,
+  VALIDATE_SCHEMA_KEY,
+  COMPRESS_METADATA_KEY,
+  TRANSFORM_MAPPER_KEY,
+  DECORATOR_PRIORITY,
+} from './constants';
+export type { DecoratorType } from './constants';
+
+// ─── Interfaces ───────────────────────────────────────────────────────────────
+export type {
+  DecoratorEntry,
+  ComposableMetadata,
+  ComposedMethodMetadata,
+  MergeStrategy,
+  MergePolicy,
+} from './interfaces/composition.interface';
+export { DEFAULT_MERGE_POLICY } from './interfaces/composition.interface';
+
+export type {
+  ParamDecoratorEntry,
+  ParamSource,
+} from './interfaces/parameter-metadata.interface';
+
+// ─── Decorators ──────────────────────────────────────────────────────────────
+export { Composable } from './decorators/composable.decorator';
+
+export { Auth } from './decorators/auth.decorator';
+export type { AuthOptions } from './decorators/auth.decorator';
+
+// ComposedRateLimit is exported as RateLimit for a clean public API.
+export { ComposedRateLimit as RateLimit } from './decorators/rate-limit.decorator';
+export type { ComposedRateLimitOptions as RateLimitOptions } from './decorators/rate-limit.decorator';
+
+export { Validate } from './decorators/validate.decorator';
+export type { ValidationSchema } from './decorators/validate.decorator';
+
+export { Cache } from './decorators/cache.decorator';
+
+export { Log } from './decorators/log.decorator';
+export type { LogLevel } from './decorators/log.decorator';
+
+export { Compress } from './decorators/compress.decorator';
+
+export { Transform } from './decorators/transform.decorator';
+export type { OutputMapper } from './decorators/transform.decorator';
+
+export {
+  Param,
+  Query,
+  Body,
+  CustomParam,
+} from './decorators/param.decorator';
+
+// ─── Guards & Interceptors (for manual registration) ─────────────────────────
+export { CompositionGuard } from './guards/composition.guard';
+export { CompositionInterceptor } from './interceptors/composition.interceptor';

--- a/backend/src/decorator-composition/interceptors/composition.interceptor.ts
+++ b/backend/src/decorator-composition/interceptors/composition.interceptor.ts
@@ -1,0 +1,114 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+  BadRequestException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import {
+  COMPOSABLE_METADATA_KEY,
+  VALIDATE_SCHEMA_KEY,
+  TRANSFORM_MAPPER_KEY,
+  COMPRESS_METADATA_KEY,
+} from '../constants';
+import { MetadataRegistryService } from '../metadata-registry.service';
+import { OutputMapper } from '../decorators/transform.decorator';
+import { ValidationSchema } from '../decorators/validate.decorator';
+
+/**
+ * CompositionInterceptor — global interceptor for the decorator composition system.
+ *
+ * Handles the following phases in priority order:
+ *
+ *  VALIDATE  (30) — runs synchronously BEFORE next.handle() is called.
+ *                   Reads the schema stored by @Validate and calls schema.validate(req.body).
+ *                   Throws BadRequestException on failure, stopping the chain.
+ *
+ *  COMPRESS  (70) — sets an X-Composition-Compress: true response header.
+ *                   Actual compression is handled by platform-level middleware.
+ *
+ *  TRANSFORM (60) — applied as pipe(map(mapper)) on the RxJS Observable returned
+ *                   by next.handle(), transforming the handler's response.
+ *
+ * AUTH  (10) and RATE_LIMIT (20) run in the guard phase (before this interceptor)
+ * via guards registered by @Auth and @ComposedRateLimit respectively.
+ *
+ * CACHE (40) and LOG (50) wrap the method descriptor directly and therefore run
+ * inside the handler invocation, not inside this interceptor.
+ *
+ * Registered as APP_INTERCEPTOR in DecoratorCompositionModule.
+ */
+@Injectable()
+export class CompositionInterceptor implements NestInterceptor {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly registry: MetadataRegistryService,
+  ) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const isComposable = this.reflector.getAllAndOverride(
+      COMPOSABLE_METADATA_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
+    // Fast path: route has not opted in
+    if (!isComposable) return next.handle();
+
+    const handler = context.getHandler();
+    const controller = context.getClass();
+
+    const composed = this.registry.getComposedMetadata(
+      controller.name,
+      handler.name,
+    );
+
+    // ── Phase: VALIDATE (priority 30) ────────────────────────────────────────
+    // Run before next.handle() so the handler never executes on invalid input.
+    if (composed.hasValidation) {
+      const schema = this.reflector.get<ValidationSchema>(
+        VALIDATE_SCHEMA_KEY,
+        handler,
+      );
+      if (schema) {
+        const req = context.switchToHttp().getRequest();
+        const { valid, errors } = schema.validate(req.body);
+        if (!valid) {
+          throw new BadRequestException({
+            message: 'Validation failed',
+            errors: errors ?? [],
+          });
+        }
+      }
+    }
+
+    // ── Phase: COMPRESS (priority 70) — set response header hint ─────────────
+    if (composed.hasCompress) {
+      const shouldCompress = this.reflector.get<boolean>(
+        COMPRESS_METADATA_KEY,
+        handler,
+      );
+      if (shouldCompress) {
+        const res = context.switchToHttp().getResponse();
+        res.setHeader('X-Composition-Compress', 'true');
+      }
+    }
+
+    // ── Phase: Execute handler + TRANSFORM (priority 60) ─────────────────────
+    let pipeline = next.handle();
+
+    if (composed.hasTransform) {
+      const mapper = this.reflector.get<OutputMapper>(
+        TRANSFORM_MAPPER_KEY,
+        handler,
+      );
+      if (mapper) {
+        pipeline = pipeline.pipe(map(mapper));
+      }
+    }
+
+    return pipeline;
+  }
+}

--- a/backend/src/decorator-composition/interfaces/composition.interface.ts
+++ b/backend/src/decorator-composition/interfaces/composition.interface.ts
@@ -1,0 +1,63 @@
+import { DecoratorType } from '../constants';
+
+// ─── Core Composition Types ───────────────────────────────────────────────────
+
+/** One entry in the per-method decoration stack */
+export interface DecoratorEntry {
+  type: DecoratorType;
+  priority: number;
+  options: Record<string, any>;
+}
+
+/** What @Composable stores on the class or method */
+export interface ComposableMetadata {
+  composable: true;
+  className?: string;
+  methodName?: string;
+}
+
+/** Full composed snapshot for a single method, returned by MetadataRegistryService */
+export interface ComposedMethodMetadata {
+  /** Entries sorted ascending by priority */
+  stack: DecoratorEntry[];
+  hasAuth: boolean;
+  hasRateLimit: boolean;
+  hasValidation: boolean;
+  hasCache: boolean;
+  hasLog: boolean;
+  hasCompress: boolean;
+  hasTransform: boolean;
+}
+
+// ─── Merge Strategies ─────────────────────────────────────────────────────────
+
+/**
+ * How to resolve conflicts when the same decorator type appears more than once
+ * on the same method.
+ *
+ * - first-wins  : keep the first-applied decorator's options
+ * - last-wins   : keep the last-applied decorator's options (innermost wins in TS)
+ * - merge       : shallow-merge all options objects (last key wins within merge)
+ * - override    : alias for last-wins
+ */
+export type MergeStrategy = 'override' | 'merge' | 'first-wins' | 'last-wins';
+
+export interface MergePolicy {
+  [decoratorType: string]: MergeStrategy;
+}
+
+/**
+ * Default precedence rules:
+ *  - AUTH, RATE_LIMIT, VALIDATE, CACHE, TRANSFORM, COMPRESS → last-wins
+ *    (the innermost / most-specific decorator's config takes effect)
+ *  - LOG → merge (combine log options so multiple @Log levels are aggregated)
+ */
+export const DEFAULT_MERGE_POLICY: MergePolicy = {
+  AUTH: 'last-wins',
+  RATE_LIMIT: 'last-wins',
+  VALIDATE: 'last-wins',
+  CACHE: 'last-wins',
+  LOG: 'merge',
+  TRANSFORM: 'last-wins',
+  COMPRESS: 'last-wins',
+};

--- a/backend/src/decorator-composition/interfaces/parameter-metadata.interface.ts
+++ b/backend/src/decorator-composition/interfaces/parameter-metadata.interface.ts
@@ -1,0 +1,13 @@
+/** Source of the parameter value extracted from the request */
+export type ParamSource = 'param' | 'query' | 'body' | 'custom';
+
+/** One entry stored per parameter position on a method */
+export interface ParamDecoratorEntry {
+  /** Zero-based index in the method's parameter list */
+  index: number;
+  source: ParamSource;
+  /** e.g. 'id' for @Param('id'); absent means "whole object" */
+  key?: string;
+  /** Custom extractor function for @CustomParam */
+  extractor?: (req: any) => any;
+}

--- a/backend/src/decorator-composition/metadata-registry.service.ts
+++ b/backend/src/decorator-composition/metadata-registry.service.ts
@@ -1,0 +1,159 @@
+import { Injectable } from '@nestjs/common';
+import {
+  DecoratorEntry,
+  ComposedMethodMetadata,
+  DEFAULT_MERGE_POLICY,
+  MergeStrategy,
+} from './interfaces/composition.interface';
+import { DecoratorType } from './constants';
+
+// ─── Pre-Init Buffer ──────────────────────────────────────────────────────────
+//
+// TypeScript decorator factories execute at class-definition time, which is
+// before the NestJS DI container exists. To bridge this gap we maintain a
+// module-level buffer that accumulates entries during the class-definition
+// phase. MetadataRegistryService drains the buffer in its constructor.
+
+interface BufferItem {
+  className: string;
+  methodName: string;
+  entry: DecoratorEntry;
+}
+
+const PRE_INIT_BUFFER: BufferItem[] = [];
+
+/**
+ * Called by every decorator factory to register a DecoratorEntry before the
+ * DI container has been initialised. MetadataRegistryService drains this
+ * buffer on construction.
+ */
+export function bufferDecoratorEntry(
+  className: string,
+  methodName: string,
+  entry: DecoratorEntry,
+): void {
+  PRE_INIT_BUFFER.push({ className, methodName, entry });
+}
+
+// ─── Service ──────────────────────────────────────────────────────────────────
+
+@Injectable()
+export class MetadataRegistryService {
+  /**
+   * Central store: "ClassName.methodName" → ordered list of DecoratorEntry.
+   * Entries are inserted in decoration order; getComposedMetadata() sorts them.
+   */
+  private readonly store = new Map<string, DecoratorEntry[]>();
+
+  constructor() {
+    // Drain the pre-init buffer populated by decorator factories.
+    for (const item of PRE_INIT_BUFFER) {
+      this.push(item.className, item.methodName, item.entry);
+    }
+  }
+
+  /**
+   * Register a single decorator entry for a method.
+   * Called by decorator factories (via bufferDecoratorEntry at definition time)
+   * and again directly from the constructor (drain phase).
+   */
+  push(className: string, methodName: string, entry: DecoratorEntry): void {
+    const key = this.buildKey(className, methodName);
+    const existing = this.store.get(key) ?? [];
+    existing.push(entry);
+    this.store.set(key, existing);
+  }
+
+  /**
+   * Return the fully composed, merged, and priority-sorted metadata for a method.
+   *
+   * Merge rules (see DEFAULT_MERGE_POLICY):
+   *  - last-wins  : only the last-registered entry for that type survives
+   *  - merge      : all entries for that type are shallow-merged (LOG)
+   */
+  getComposedMetadata(
+    className: string,
+    methodName: string,
+  ): ComposedMethodMetadata {
+    const key = this.buildKey(className, methodName);
+    const raw = this.store.get(key) ?? [];
+    const merged = this.mergeStack(raw);
+    const sorted = [...merged].sort((a, b) => a.priority - b.priority);
+
+    return {
+      stack: sorted,
+      hasAuth: sorted.some(e => e.type === 'AUTH'),
+      hasRateLimit: sorted.some(e => e.type === 'RATE_LIMIT'),
+      hasValidation: sorted.some(e => e.type === 'VALIDATE'),
+      hasCache: sorted.some(e => e.type === 'CACHE'),
+      hasLog: sorted.some(e => e.type === 'LOG'),
+      hasCompress: sorted.some(e => e.type === 'COMPRESS'),
+      hasTransform: sorted.some(e => e.type === 'TRANSFORM'),
+    };
+  }
+
+  /**
+   * Return a plain-object snapshot of the full registry.
+   * Useful for debugging and diagnostic endpoints.
+   */
+  listAll(): Record<string, DecoratorEntry[]> {
+    return Object.fromEntries(this.store.entries());
+  }
+
+  /**
+   * Clear the registry. Intended for use between test cases.
+   */
+  clear(): void {
+    this.store.clear();
+  }
+
+  // ─── Private helpers ──────────────────────────────────────────────────────
+
+  private buildKey(className: string, methodName: string): string {
+    return `${className}.${methodName}`;
+  }
+
+  /**
+   * Group entries by type and apply the merge strategy for each type.
+   * Returns one representative entry per type.
+   */
+  private mergeStack(entries: DecoratorEntry[]): DecoratorEntry[] {
+    const byType = new Map<DecoratorType, DecoratorEntry[]>();
+
+    for (const entry of entries) {
+      const group = byType.get(entry.type) ?? [];
+      group.push(entry);
+      byType.set(entry.type, group);
+    }
+
+    const result: DecoratorEntry[] = [];
+    for (const [type, group] of byType.entries()) {
+      const strategy: MergeStrategy = DEFAULT_MERGE_POLICY[type] ?? 'last-wins';
+      result.push(this.applyMergeStrategy(group, strategy));
+    }
+    return result;
+  }
+
+  private applyMergeStrategy(
+    group: DecoratorEntry[],
+    strategy: MergeStrategy,
+  ): DecoratorEntry {
+    switch (strategy) {
+      case 'first-wins':
+        return group[0];
+
+      case 'merge': {
+        const merged = group.reduce(
+          (acc, e) => ({ ...acc, ...e.options }),
+          {} as Record<string, any>,
+        );
+        return { ...group[0], options: merged };
+      }
+
+      case 'override':
+      case 'last-wins':
+      default:
+        return group[group.length - 1];
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements a complete **Decorator Composition Pattern with Metadata** system for the NestJS backend, fulfilling all requirements of issue #143. The system enables multiple decorators to be stacked on controller methods with guaranteed execution order, metadata integrity, and zero conflicts.

---

## What Was Built

### Core Architecture

**Pre-init Buffer + Metadata Registry**

The central challenge is that TypeScript decorator factories run at *class-definition time*, before the NestJS DI container exists. This is solved with a **pre-init buffer** pattern:

1. A module-level `PRE_INIT_BUFFER` array accumulates `DecoratorEntry` objects as classes are defined.
2. `MetadataRegistryService` drains the buffer in its constructor (called by NestJS at bootstrap), populating a `Map<"ClassName.methodName", DecoratorEntry[]>`.
3. At request time, `CompositionGuard` and `CompositionInterceptor` query the registry to read composed metadata.

---

### Files Added (`backend/src/decorator-composition/`)

```
decorator-composition/
├── constants.ts                          # Metadata keys + DECORATOR_PRIORITY table
├── decorator-composition.module.ts       # @Global NestJS module
├── index.ts                              # Barrel re-exports
├── metadata-registry.service.ts          # Pre-init buffer + central Map store
├── interfaces/
│   ├── composition.interface.ts          # DecoratorEntry, ComposedMethodMetadata, MergePolicy
│   └── parameter-metadata.interface.ts   # ParamDecoratorEntry, ParamSource
├── decorators/
│   ├── composable.decorator.ts           # @Composable() opt-in marker
│   ├── auth.decorator.ts                 # @Auth(options) wraps JwtAuthGuard + PermissionGuard
│   ├── rate-limit.decorator.ts           # @RateLimit(req, win) wraps existing RateLimit
│   ├── validate.decorator.ts             # @Validate(schema) duck-typed validation
│   ├── cache.decorator.ts                # @Cache(ttl) wraps existing @Cacheable
│   ├── log.decorator.ts                  # @Log(level?) descriptor wrapper
│   ├── compress.decorator.ts             # @Compress() response header hint
│   ├── transform.decorator.ts            # @Transform(mapper) RxJS pipe(map)
│   └── param.decorator.ts                # @Param, @Query, @Body, @CustomParam
├── guards/
│   └── composition.guard.ts              # Ordering integrity + early termination gate
├── interceptors/
│   └── composition.interceptor.ts        # VALIDATE / TRANSFORM / COMPRESS phases
└── __tests__/
    ├── metadata-registry.spec.ts         # 12 unit tests (pure, no NestJS module)
    ├── composition.spec.ts               # 11 integration tests
    ├── execution-order.spec.ts           # 7 integration tests
    └── error-scenarios.spec.ts           # 8 integration tests
```

### Files Modified

- `backend/src/app.module.ts` — registers `DecoratorCompositionModule` globally

---

### Decorator Execution Order

Priority numbers are fixed constants — lower runs first:

| Priority | Decorator | Phase | Early Termination |
|---|---|---|---|
| 10 | `@Auth` | Guard (JwtAuthGuard + PermissionGuard) | ✅ Yes |
| 20 | `@RateLimit` | Guard (RateLimitGuard) | ✅ Yes |
| 30 | `@Validate` | Interceptor — before `next.handle()` | ✅ Throws 400 |
| 40 | `@Cache` | Descriptor wrapper (inside handler) | ✅ Cache hit skips handler |
| 50 | `@Log` | Descriptor wrapper (surrounds handler) | ❌ No |
| 60 | `@Transform` | Interceptor — `pipe(map(mapper))` | ❌ No |
| 70 | `@Compress` | Interceptor — response header | ❌ No |

---

### Metadata Merge Strategies

When the same decorator type appears more than once on a method, the `MetadataRegistryService` resolves conflicts using defined strategies:

| Decorator Type | Strategy | Rationale |
|---|---|---|
| `AUTH` | last-wins | Most-specific (topmost) config takes effect |
| `RATE_LIMIT` | last-wins | Most-specific limit wins |
| `VALIDATE` | last-wins | Most-specific schema wins |
| `CACHE` | last-wins | Most-specific TTL wins |
| `LOG` | merge | Options shallow-merged (combines log levels) |
| `TRANSFORM` | last-wins | Most-specific mapper wins |
| `COMPRESS` | last-wins | Single flag; last declaration wins |

> **Note on TS decorator order:** TypeScript applies decorators bottom-to-top, so the *topmost* decorator of a type in source code is the "last" to execute and wins under last-wins semantics.

---

### Composition Patterns Implemented

**Serial composition (auth → validate → execute):**
```typescript
@Composable()
@Auth({ resource: 'orders', action: Action.CREATE })
@Validate(createOrderSchema)
createOrder(@Body() dto: CreateOrderDto) { ... }
```
AUTH guard runs first; if it passes, VALIDATE runs in the interceptor before the handler body.

**Parallel metadata (cache + log):**
```typescript
@Composable()
@Cache(300, 'profiles')
@Log('debug')
getProfile(@Param('id') id: string) { ... }
```
Both decorators register independently. Cache may short-circuit the handler; Log always wraps it.

**Transform output:**
```typescript
@Composable()
@Transform(items => ({ data: items, count: items.length }))
listOrders() { ... }
```

**Conditional opt-in:**
Methods/classes without `@Composable()` are completely transparent to the system — zero overhead on non-participating routes.

---

### Parameter Decorators

All four parameter decorators store `ParamDecoratorEntry` metadata via `Reflect.defineMetadata` and delegate extraction to `createParamDecorator`:

```typescript
getUser(@Param('id') id: string) { ... }
search(@Query('q') q: string) { ... }
create(@Body() dto: CreateOrderDto) { ... }
report(@CustomParam(req => req.user.id) userId: string) { ... }
```

---

## Test Results

**38/38 tests passing** across 4 test suites:

```
PASS src/decorator-composition/__tests__/metadata-registry.spec.ts  (12 tests)
PASS src/decorator-composition/__tests__/composition.spec.ts         (11 tests)
PASS src/decorator-composition/__tests__/execution-order.spec.ts     (7 tests)
PASS src/decorator-composition/__tests__/error-scenarios.spec.ts     (8 tests)

Test Suites: 4 passed, 4 total
Tests:       38 passed, 38 total
```

**Coverage includes:**
- Metadata storage, retrieval, and merge (all 4 strategies)
- Stack sorted ascending by priority
- Boolean flags (`hasAuth`, `hasCache`, etc.)
- Serial order enforced: @Validate blocks handler on failure (400)
- Transform applied after handler via RxJS
- Compress header set correctly
- @Log wraps async handlers without breaking routes
- Duplicate decorator merge and last-wins behaviour
- Error propagation from schema throws and mapper throws
- Routes without @Composable pass through unaffected

---

## Design Decisions

1. **Wraps existing decorators, never recreates them.** `@Cache` calls `@Cacheable`, `@Auth` calls `JwtAuthGuard`/`PermissionGuard`/`RequirePermission`, `@RateLimit` calls the existing `RateLimit`. This preserves all existing guard/interceptor infrastructure.

2. **`@Composable()` is required for the system to activate.** This is a deliberate opt-in design — routes that don't use composition have zero runtime overhead from the global guard/interceptor.

3. **`@Log` copies `Reflect.getMetadataKeys`** from the original method to the wrapper. This prevents NestJS route metadata (path, method verb) from being lost when the descriptor is replaced.

4. **`APP_GUARD`/`APP_INTERCEPTOR` registration** in `DecoratorCompositionModule` means consumers only need to import the module once. In tests, guard/interceptor are registered manually via `app.useGlobalGuards()`/`app.useGlobalInterceptors()` to avoid the `APP_GUARD` token resolution issue in isolated test modules.

---

Closes #143
