### PR TITLE
perf: resolve issues #237 #238 #239 #240

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -67,6 +67,7 @@
     "rxjs": "^7.8.1",
     "socket.io": "^4.8.1",
     "socket.io-client": "^4.8.1",
+    "@socket.io/redis-adapter": "^8.3.0",
     "stellar-sdk": "^11.2.2",
     "supertest": "^7.2.2",
     "typeorm": "^0.3.19",

--- a/backend/src/agent/indexer.service.ts
+++ b/backend/src/agent/indexer.service.ts
@@ -83,6 +83,11 @@ export class IndexerService {
     return agent;
   }
 
+  /** Batch-load agents by IDs — used by DataLoader to avoid N+1 queries */
+  async findByIds(ids: string[]): Promise<Agent[]> {
+    return this.agentRepository.findBy({ id: In(ids) as any });
+  }
+
   @CacheInvalidate({
     rule: 'agent:performance-update',
     keys: (id: string) => [`agent:${id}`],

--- a/backend/src/analytics/analytics.gateway.ts
+++ b/backend/src/analytics/analytics.gateway.ts
@@ -1,31 +1,117 @@
-import { Logger } from '@nestjs/common';
+import { Logger, OnModuleDestroy } from '@nestjs/common';
 import {
   OnGatewayConnection,
   OnGatewayDisconnect,
+  OnGatewayInit,
+  SubscribeMessage,
   WebSocketGateway,
   WebSocketServer,
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
+import { createAdapter } from '@socket.io/redis-adapter';
+import { createClient } from 'redis';
 
+const HEARTBEAT_INTERVAL_MS = 25_000;
+const HEARTBEAT_TIMEOUT_MS = 60_000;
+
+/**
+ * Issue #240 — Optimize WebSocket Connections
+ *
+ * Improvements:
+ * - Heartbeat ping/pong to detect and evict stale connections
+ * - Per-connection tracking (count + last-seen timestamp)
+ * - Redis adapter for horizontal scaling / load balancing
+ */
 @WebSocketGateway({
   namespace: 'analytics',
   cors: { origin: '*' },
+  transports: ['websocket'],
 })
-export class AnalyticsGateway implements OnGatewayConnection, OnGatewayDisconnect {
+export class AnalyticsGateway
+  implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect, OnModuleDestroy
+{
   @WebSocketServer()
   server: Server;
 
   private readonly logger = new Logger(AnalyticsGateway.name);
 
+  /** client id → last heartbeat timestamp */
+  private readonly connections = new Map<string, number>();
+
+  private heartbeatTimer: NodeJS.Timeout | null = null;
+
+  // ── Lifecycle ──────────────────────────────────────────────────────────────
+
+  async afterInit(server: Server): Promise<void> {
+    await this.attachRedisAdapter(server);
+    this.startHeartbeat();
+    this.logger.log('AnalyticsGateway initialised');
+  }
+
   handleConnection(client: Socket): void {
-    this.logger.debug(`Analytics client connected: ${client.id}`);
+    this.connections.set(client.id, Date.now());
+    this.logger.debug(`Client connected: ${client.id} (total: ${this.connections.size})`);
   }
 
   handleDisconnect(client: Socket): void {
-    this.logger.debug(`Analytics client disconnected: ${client.id}`);
+    this.connections.delete(client.id);
+    this.logger.debug(`Client disconnected: ${client.id} (total: ${this.connections.size})`);
   }
+
+  onModuleDestroy(): void {
+    if (this.heartbeatTimer) clearInterval(this.heartbeatTimer);
+  }
+
+  // ── Heartbeat ──────────────────────────────────────────────────────────────
+
+  @SubscribeMessage('pong')
+  handlePong(client: Socket): void {
+    this.connections.set(client.id, Date.now());
+  }
+
+  private startHeartbeat(): void {
+    this.heartbeatTimer = setInterval(() => {
+      const now = Date.now();
+      for (const [id, lastSeen] of this.connections) {
+        if (now - lastSeen > HEARTBEAT_TIMEOUT_MS) {
+          this.logger.warn(`Evicting stale connection: ${id}`);
+          this.server.sockets.sockets.get(id)?.disconnect(true);
+          this.connections.delete(id);
+        }
+      }
+      // Ping all remaining clients
+      this.server.emit('ping');
+    }, HEARTBEAT_INTERVAL_MS);
+  }
+
+  // ── Broadcasting ───────────────────────────────────────────────────────────
 
   broadcastUpdate(payload: unknown): void {
     this.server.emit('analytics:update', payload);
   }
+
+  getConnectionCount(): number {
+    return this.connections.size;
+  }
+
+  // ── Redis adapter (load balancing) ─────────────────────────────────────────
+
+  private async attachRedisAdapter(server: Server): Promise<void> {
+    const redisUrl = process.env.REDIS_URL;
+    if (!redisUrl) {
+      this.logger.warn('REDIS_URL not set — running without Redis adapter (single-node mode)');
+      return;
+    }
+
+    try {
+      const pubClient = createClient({ url: redisUrl });
+      const subClient = pubClient.duplicate();
+      await Promise.all([pubClient.connect(), subClient.connect()]);
+      server.adapter(createAdapter(pubClient, subClient));
+      this.logger.log('Redis adapter attached for WebSocket load balancing');
+    } catch (err) {
+      this.logger.error('Failed to attach Redis adapter — falling back to in-memory', err);
+    }
+  }
 }
+

--- a/backend/src/cache/__tests__/market-cache.service.spec.ts
+++ b/backend/src/cache/__tests__/market-cache.service.spec.ts
@@ -1,0 +1,73 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MarketCacheService } from '../market-cache.service';
+import { CacheManager } from '../cache-manager.service';
+
+const mockCache = {
+  get: jest.fn(),
+  set: jest.fn(),
+  del: jest.fn(),
+  getOrSet: jest.fn(),
+};
+
+describe('MarketCacheService', () => {
+  let service: MarketCacheService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MarketCacheService,
+        { provide: CacheManager, useValue: mockCache },
+      ],
+    }).compile();
+
+    service = module.get(MarketCacheService);
+    jest.clearAllMocks();
+  });
+
+  describe('market prices', () => {
+    it('gets a cached price', async () => {
+      mockCache.get.mockResolvedValue('1.23');
+      expect(await service.getMarketPrice('XLM/USD')).toBe('1.23');
+      expect(mockCache.get).toHaveBeenCalledWith('market:price:XLM/USD');
+    });
+
+    it('sets a price with 10 s TTL', async () => {
+      await service.setMarketPrice('XLM/USD', '1.23');
+      expect(mockCache.set).toHaveBeenCalledWith('market:price:XLM/USD', '1.23', { ttl: 10 });
+    });
+
+    it('invalidates a price', async () => {
+      await service.invalidateMarketPrice('XLM/USD');
+      expect(mockCache.del).toHaveBeenCalledWith('market:price:XLM/USD');
+    });
+  });
+
+  describe('portfolios', () => {
+    it('gets a cached portfolio', async () => {
+      const portfolio = { assets: [] };
+      mockCache.get.mockResolvedValue(portfolio);
+      expect(await service.getPortfolio('user-1')).toEqual(portfolio);
+    });
+
+    it('sets a portfolio with 60 s TTL', async () => {
+      const portfolio = { assets: [] };
+      await service.setPortfolio('user-1', portfolio);
+      expect(mockCache.set).toHaveBeenCalledWith('portfolio:user-1', portfolio, { ttl: 60 });
+    });
+
+    it('invalidates a portfolio', async () => {
+      await service.invalidatePortfolio('user-1');
+      expect(mockCache.del).toHaveBeenCalledWith('portfolio:user-1');
+    });
+  });
+
+  describe('cache-aside', () => {
+    it('returns cached value without calling fetch', async () => {
+      mockCache.getOrSet.mockResolvedValue('1.23');
+      const fetch = jest.fn();
+      const result = await service.getOrFetchMarketPrice('XLM/USD', fetch);
+      expect(result).toBe('1.23');
+      expect(mockCache.getOrSet).toHaveBeenCalledWith('market:price:XLM/USD', fetch, { ttl: 10 });
+    });
+  });
+});

--- a/backend/src/cache/cache.module.ts
+++ b/backend/src/cache/cache.module.ts
@@ -4,6 +4,7 @@ import { CacheManager } from './cache-manager.service';
 import { CacheInvalidator } from './cache-invalidator.service';
 import { CacheMetricsService } from './cache-metrics.service';
 import { CacheController } from './cache.controller';
+import { MarketCacheService } from './market-cache.service';
 
 // Multi-level cache services
 import { L1CacheService } from './l1-cache.service';
@@ -23,10 +24,11 @@ import { CacheStatsService } from './cache-stats.service';
   controllers: [CacheController],
   providers: [
     // Standard cache services
-    CacheManager, 
-    CacheInvalidator, 
+    CacheManager,
+    CacheInvalidator,
     CacheMetricsService,
-    
+    MarketCacheService,
+
     // Multi-level cache services
     L1CacheService,
     L2CacheService,
@@ -35,10 +37,11 @@ import { CacheStatsService } from './cache-stats.service';
   ],
   exports: [
     // Standard cache services
-    CacheManager, 
-    CacheInvalidator, 
+    CacheManager,
+    CacheInvalidator,
     CacheMetricsService,
-    
+    MarketCacheService,
+
     // Multi-level cache services
     L1CacheService,
     L2CacheService,

--- a/backend/src/cache/market-cache.service.ts
+++ b/backend/src/cache/market-cache.service.ts
@@ -1,0 +1,58 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { CacheManager } from '../cache/cache-manager.service';
+
+const MARKET_PRICE_TTL = 10;    // 10 s — highly volatile
+const PORTFOLIO_TTL = 60;       // 60 s — less volatile
+
+@Injectable()
+export class MarketCacheService {
+  private readonly logger = new Logger(MarketCacheService.name);
+
+  constructor(private readonly cache: CacheManager) {}
+
+  // ── Market prices ──────────────────────────────────────────────────────────
+
+  async getMarketPrice(pair: string): Promise<string | undefined> {
+    return this.cache.get<string>(`market:price:${pair}`);
+  }
+
+  async setMarketPrice(pair: string, price: string): Promise<void> {
+    await this.cache.set(`market:price:${pair}`, price, { ttl: MARKET_PRICE_TTL });
+    this.logger.debug(`Cached market price for ${pair}`);
+  }
+
+  async invalidateMarketPrice(pair: string): Promise<void> {
+    await this.cache.del(`market:price:${pair}`);
+  }
+
+  // ── User portfolios ────────────────────────────────────────────────────────
+
+  async getPortfolio(userId: string): Promise<unknown | undefined> {
+    return this.cache.get<unknown>(`portfolio:${userId}`);
+  }
+
+  async setPortfolio(userId: string, portfolio: unknown): Promise<void> {
+    await this.cache.set(`portfolio:${userId}`, portfolio, { ttl: PORTFOLIO_TTL });
+    this.logger.debug(`Cached portfolio for user ${userId}`);
+  }
+
+  async invalidatePortfolio(userId: string): Promise<void> {
+    await this.cache.del(`portfolio:${userId}`);
+  }
+
+  // ── Cache-aside helpers ────────────────────────────────────────────────────
+
+  async getOrFetchMarketPrice(
+    pair: string,
+    fetch: () => Promise<string>,
+  ): Promise<string> {
+    return this.cache.getOrSet(`market:price:${pair}`, fetch, { ttl: MARKET_PRICE_TTL });
+  }
+
+  async getOrFetchPortfolio(
+    userId: string,
+    fetch: () => Promise<unknown>,
+  ): Promise<unknown> {
+    return this.cache.getOrSet(`portfolio:${userId}`, fetch, { ttl: PORTFOLIO_TTL });
+  }
+}

--- a/backend/src/database/migrations/1745358313000-AddTradingAnalyticsIndexes.ts
+++ b/backend/src/database/migrations/1745358313000-AddTradingAnalyticsIndexes.ts
@@ -1,0 +1,91 @@
+import { MigrationInterface, QueryRunner, TableIndex } from 'typeorm';
+
+/**
+ * Issue #237 — Optimize Database Query Performance
+ * Adds indexes for high-frequency queries in trading and analytics modules.
+ */
+export class AddTradingAnalyticsIndexes1745358313000 implements MigrationInterface {
+  name = 'AddTradingAnalyticsIndexes1745358313000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // oracle_snapshots — pair + timestamp is the hottest query path
+    await queryRunner.createIndex(
+      'oracle_snapshots',
+      new TableIndex({
+        name: 'IDX_ORACLE_SNAPSHOTS_PAIR_TIMESTAMP',
+        columnNames: ['pair', 'timestamp'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'oracle_snapshots',
+      new TableIndex({
+        name: 'IDX_ORACLE_SNAPSHOTS_TIMESTAMP',
+        columnNames: ['timestamp'],
+      }),
+    );
+
+    // submissions — status + created_at for queue polling
+    await queryRunner.createIndex(
+      'submissions',
+      new TableIndex({
+        name: 'IDX_SUBMISSIONS_STATUS_CREATED_AT',
+        columnNames: ['status', 'created_at'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'submissions',
+      new TableIndex({
+        name: 'IDX_SUBMISSIONS_IDEMPOTENCY_KEY',
+        columnNames: ['idempotency_key'],
+        isUnique: true,
+      }),
+    );
+
+    // audit_logs — wallet + event_type + timestamp for analytics dashboards
+    await queryRunner.createIndex(
+      'audit_logs',
+      new TableIndex({
+        name: 'IDX_AUDIT_LOGS_WALLET_EVENT_TIMESTAMP',
+        columnNames: ['wallet', 'event_type', 'timestamp'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'audit_logs',
+      new TableIndex({
+        name: 'IDX_AUDIT_LOGS_TIMESTAMP',
+        columnNames: ['timestamp'],
+      }),
+    );
+
+    // agents — is_active + evolution_level for search/filter queries
+    await queryRunner.createIndex(
+      'agents',
+      new TableIndex({
+        name: 'IDX_AGENTS_ACTIVE_EVOLUTION',
+        columnNames: ['is_active', 'evolution_level'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'agents',
+      new TableIndex({
+        name: 'IDX_AGENTS_CREATED_AT',
+        columnNames: ['created_at'],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropIndex('oracle_snapshots', 'IDX_ORACLE_SNAPSHOTS_PAIR_TIMESTAMP');
+    await queryRunner.dropIndex('oracle_snapshots', 'IDX_ORACLE_SNAPSHOTS_TIMESTAMP');
+    await queryRunner.dropIndex('submissions', 'IDX_SUBMISSIONS_STATUS_CREATED_AT');
+    await queryRunner.dropIndex('submissions', 'IDX_SUBMISSIONS_IDEMPOTENCY_KEY');
+    await queryRunner.dropIndex('audit_logs', 'IDX_AUDIT_LOGS_WALLET_EVENT_TIMESTAMP');
+    await queryRunner.dropIndex('audit_logs', 'IDX_AUDIT_LOGS_TIMESTAMP');
+    await queryRunner.dropIndex('agents', 'IDX_AGENTS_ACTIVE_EVOLUTION');
+    await queryRunner.dropIndex('agents', 'IDX_AGENTS_CREATED_AT');
+  }
+}

--- a/backend/src/graphql/dataloader.service.ts
+++ b/backend/src/graphql/dataloader.service.ts
@@ -1,0 +1,52 @@
+import { Injectable, Scope } from '@nestjs/common';
+import DataLoader from 'dataloader';
+import { IndexerService } from '../agent/indexer.service';
+import { OracleService } from '../oracle/oracle.service';
+import { SubmitterService } from '../submitter/submitter.service';
+
+/**
+ * Issue #239 — Reduce Memory Usage in GraphQL Resolvers
+ *
+ * REQUEST-scoped so each GraphQL request gets its own DataLoader instances,
+ * which batch and deduplicate DB calls within a single request tick.
+ */
+@Injectable({ scope: Scope.REQUEST })
+export class DataLoaderService {
+  constructor(
+    private readonly indexerService: IndexerService,
+    private readonly oracleService: OracleService,
+    private readonly submitterService: SubmitterService,
+  ) {}
+
+  /** Batch-load agents by ID */
+  readonly agentLoader = new DataLoader<string, unknown>(
+    async (ids: readonly string[]) => {
+      const agents = await this.indexerService.findByIds([...ids]);
+      const map = new Map(agents.map((a: any) => [a.id, a]));
+      return ids.map((id) => map.get(id) ?? null);
+    },
+    { maxBatchSize: 100 },
+  );
+
+  /** Batch-load oracle snapshots by ID */
+  readonly oracleLoader = new DataLoader<string, unknown>(
+    async (ids: readonly string[]) => {
+      const snapshots = await Promise.all(
+        ids.map((id) => this.oracleService.getSnapshotAsOracle(id).catch(() => null)),
+      );
+      return snapshots;
+    },
+    { maxBatchSize: 50 },
+  );
+
+  /** Batch-load submissions by ID */
+  readonly submissionLoader = new DataLoader<string, unknown>(
+    async (ids: readonly string[]) => {
+      const submissions = await Promise.all(
+        ids.map((id) => this.submitterService.getSubmission(id).catch(() => null)),
+      );
+      return submissions;
+    },
+    { maxBatchSize: 100 },
+  );
+}

--- a/backend/src/graphql/graphql.module.ts
+++ b/backend/src/graphql/graphql.module.ts
@@ -14,6 +14,7 @@ import { AuditLogResolver } from './resolvers/audit-log.resolver';
 import { GraphqlPubSub } from './pubsub.service';
 import { GqlJwtAuthGuard } from './guards/gql-jwt-auth.guard';
 import { formatGraphqlError } from './graphql-error.formatter';
+import { DataLoaderService } from './dataloader.service';
 
 @Module({
   imports: [
@@ -60,6 +61,7 @@ import { formatGraphqlError } from './graphql-error.formatter';
     AuditLogResolver,
     GraphqlPubSub,
     GqlJwtAuthGuard,
+    DataLoaderService,
   ],
 })
 export class GraphqlApiModule {}

--- a/backend/src/graphql/resolvers/agent.resolver.ts
+++ b/backend/src/graphql/resolvers/agent.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Mutation, Query, Resolver, Subscription } from '@nestjs/graphql';
+import { Args, Context, Mutation, Query, Resolver, Subscription } from '@nestjs/graphql';
 import { UseGuards } from '@nestjs/common';
 import { IndexerService } from '../../agent/indexer.service';
 import {
@@ -9,17 +9,22 @@ import {
 import { GraphqlPubSub } from '../pubsub.service';
 import { AGENT_UPDATED_EVENT } from '../graphql.constants';
 import { GqlJwtAuthGuard } from '../guards/gql-jwt-auth.guard';
+import { DataLoaderService } from '../dataloader.service';
+
+const MAX_PAGE_SIZE = 100;
 
 @Resolver('Agent')
 export class AgentResolver {
   constructor(
     private readonly indexerService: IndexerService,
     private readonly pubSub: GraphqlPubSub,
+    private readonly dataLoaderService: DataLoaderService,
   ) {}
 
   @Query('agent')
   async agent(@Args('id') id: string) {
-    return this.indexerService.findOne(id);
+    // Use DataLoader to batch/deduplicate single-item lookups
+    return this.dataLoaderService.agentLoader.load(id);
   }
 
   @Query('agents')
@@ -28,11 +33,12 @@ export class AgentResolver {
     @Args('offset', { nullable: true }) offset = 0,
     @Args('filter', { nullable: true }) filter?: AgentFilterInput,
   ) {
-    const page = Math.floor(offset / limit) + 1;
+    const safeLimit = Math.min(limit, MAX_PAGE_SIZE);
+    const page = Math.floor(offset / safeLimit) + 1;
     const result = await this.indexerService.search({
       ...(filter || {}),
       page,
-      limit,
+      limit: safeLimit,
     });
     return result.data;
   }
@@ -43,11 +49,12 @@ export class AgentResolver {
     @Args('limit', { nullable: true }) limit = 10,
     @Args('offset', { nullable: true }) offset = 0,
   ) {
-    const page = Math.floor(offset / limit) + 1;
+    const safeLimit = Math.min(limit, MAX_PAGE_SIZE);
+    const page = Math.floor(offset / safeLimit) + 1;
     const result = await this.indexerService.search({
       name: term,
       page,
-      limit,
+      limit: safeLimit,
     });
     return result.data;
   }


### PR DESCRIPTION
#237 - Add DB indexes migration for trading/analytics tables
  - Composite indexes on oracle_snapshots(pair, timestamp)
  - Composite index on submissions(status, created_at)
  - Unique index on submissions(idempotency_key)
  - Composite index on audit_logs(wallet, event_type, timestamp)
  - Composite index on agents(is_active, evolution_level)

#238 - Redis caching for market prices and user portfolios
  - MarketCacheService with cache-aside pattern
  - Market price TTL: 10s (volatile), portfolio TTL: 60s
  - Cache invalidation on data updates
  - Unit tests (7 passing)

#239 - DataLoader batching + pagination in GraphQL resolvers
  - REQUEST-scoped DataLoaderService for agent/oracle/submission loaders
  - AgentResolver.agent() now uses DataLoader to batch/deduplicate
  - Enforced MAX_PAGE_SIZE=100 on agents/searchAgents queries
  - IndexerService.findByIds() added for efficient batch loading

#240 - WebSocket gateway optimisation
  - Heartbeat ping every 25s, evict stale connections after 60s
  - Per-connection tracking map (id → last-seen timestamp)
  - Redis adapter (@socket.io/redis-adapter) for horizontal scaling
  - Graceful fallback to in-memory when REDIS_URL is not set
  
  closes #237 
closes #238 
closes #239 
closes #240 