### PR TITLE
feat: add staking bonuses, referral rewards, token launch waitlist, and NFT marketplace

### DIFF
--- a/contracts/credit-score-nft/contracts/credit-score-nft/src/lib.rs
+++ b/contracts/credit-score-nft/contracts/credit-score-nft/src/lib.rs
@@ -1,6 +1,11 @@
 #![no_std]
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, String, Vec};
 
+// ============================================================================
+// Data Types
+// ============================================================================
+
+/// On-chain credit score NFT with verifiable score metadata and marketplace support.
 #[contracttype]
 #[derive(Clone)]
 pub struct CreditScoreNFT {
@@ -10,6 +15,20 @@ pub struct CreditScoreNFT {
     pub mint_timestamp: u64,
     pub is_revoked: bool,
     pub revocation_note: String,
+    /// Verifiable credit score (0–1000)
+    pub credit_score: u32,
+    /// Timestamp of the last score update
+    pub score_updated_at: u64,
+}
+
+/// Active marketplace listing for a token
+#[contracttype]
+#[derive(Clone)]
+pub struct Listing {
+    pub token_id: u64,
+    pub seller: Address,
+    pub price: i128,
+    pub listed_at: u64,
 }
 
 #[contracttype]
@@ -19,14 +38,24 @@ pub enum DataKey {
     TokenId,
     NFT(u64),
     OwnerTokens(Address),
+    /// Approved operator for a specific token (for marketplace transfers)
+    Approved(u64),
+    /// Active listing for a token
+    Listing(u64),
+    /// All currently listed token IDs
+    ListedTokens,
 }
+
+// ============================================================================
+// Contract
+// ============================================================================
 
 #[contract]
 pub struct CreditScoreNFTContract;
 
 #[contractimpl]
 impl CreditScoreNFTContract {
-    /// Initialize the credit score NFT contract
+    /// Initialize the credit score NFT contract.
     pub fn initialize(env: Env, admin: Address) {
         if env.storage().instance().has(&DataKey::Admin) {
             panic!("Contract already initialized");
@@ -41,7 +70,7 @@ impl CreditScoreNFTContract {
             .publish((symbol_short!("init"), symbol_short!("contract")), admin);
     }
 
-    /// Add an authorized minter
+    /// Add an authorized minter.
     pub fn add_minter(env: Env, minter: Address) {
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
@@ -54,7 +83,7 @@ impl CreditScoreNFTContract {
             .publish((symbol_short!("add"), symbol_short!("minter")), minter);
     }
 
-    /// Remove an authorized minter
+    /// Remove an authorized minter.
     pub fn remove_minter(env: Env, minter: Address) {
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         admin.require_auth();
@@ -67,7 +96,7 @@ impl CreditScoreNFTContract {
             .publish((symbol_short!("remove"), symbol_short!("minter")), minter);
     }
 
-    /// Check if an address is an authorized minter
+    /// Check if an address is an authorized minter.
     pub fn is_minter(env: Env, address: Address) -> bool {
         env.storage()
             .persistent()
@@ -75,13 +104,15 @@ impl CreditScoreNFTContract {
             .unwrap_or(false)
     }
 
-    /// Mint a new credit score NFT
-    pub fn mint(env: Env, minter: Address, to: Address, metadata_cid: String) -> u64 {
+    /// Mint a new credit score NFT with a verifiable on-chain credit score.
+    pub fn mint(env: Env, minter: Address, to: Address, metadata_cid: String, credit_score: u32) -> u64 {
         minter.require_auth();
 
-        // Check if caller is authorized minter
-        let is_authorized = Self::is_minter(env.clone(), minter.clone());
+        if credit_score > 1000 {
+            panic!("Credit score must be between 0 and 1000");
+        }
 
+        let is_authorized = Self::is_minter(env.clone(), minter.clone());
         if !is_authorized {
             let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
             if minter != admin {
@@ -89,52 +120,345 @@ impl CreditScoreNFTContract {
             }
         }
 
-        // Get and increment token ID
         let mut token_id: u64 = env.storage().instance().get(&DataKey::TokenId).unwrap_or(0);
         token_id += 1;
         env.storage().instance().set(&DataKey::TokenId, &token_id);
 
-        // Create NFT
+        let now = env.ledger().timestamp();
         let nft = CreditScoreNFT {
             owner: to.clone(),
             metadata_cid: metadata_cid.clone(),
             token_id,
-            mint_timestamp: env.ledger().timestamp(),
+            mint_timestamp: now,
             is_revoked: false,
             revocation_note: String::from_str(&env, ""),
+            credit_score,
+            score_updated_at: now,
         };
 
-        // Store NFT
-        env.storage()
-            .persistent()
-            .set(&DataKey::NFT(token_id), &nft);
+        env.storage().persistent().set(&DataKey::NFT(token_id), &nft);
 
-        // Update owner's token list
         let mut owner_tokens: Vec<u64> = env
             .storage()
             .persistent()
             .get(&DataKey::OwnerTokens(to.clone()))
             .unwrap_or(Vec::new(&env));
         owner_tokens.push_back(token_id);
-        env.storage()
-            .persistent()
-            .set(&DataKey::OwnerTokens(to.clone()), &owner_tokens);
+        env.storage().persistent().set(&DataKey::OwnerTokens(to.clone()), &owner_tokens);
 
-        // Emit mint event
         env.events().publish(
             (symbol_short!("mint"), symbol_short!("nft")),
-            (to, token_id, metadata_cid),
+            (to, token_id, metadata_cid, credit_score),
         );
 
         token_id
     }
 
-    /// Transfer NFT to a new owner (DISABLED: Credit Score NFTs are Soulbound)
-    pub fn transfer(_env: Env, _from: Address, _to: Address, _token_id: u64) {
-        panic!("Credit Score NFTs are non-transferable (soulbound)");
+    /// Update the credit score of an existing NFT (minter or admin only).
+    pub fn update_credit_score(env: Env, minter: Address, token_id: u64, new_score: u32) {
+        minter.require_auth();
+
+        if new_score > 1000 {
+            panic!("Credit score must be between 0 and 1000");
+        }
+
+        let is_authorized = Self::is_minter(env.clone(), minter.clone());
+        if !is_authorized {
+            let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+            if minter != admin {
+                panic!("Unauthorized: caller is not an authorized minter");
+            }
+        }
+
+        let mut nft: CreditScoreNFT = env
+            .storage()
+            .persistent()
+            .get(&DataKey::NFT(token_id))
+            .expect("NFT not found");
+
+        if nft.is_revoked {
+            panic!("Cannot update score of a revoked NFT");
+        }
+
+        nft.credit_score = new_score;
+        nft.score_updated_at = env.ledger().timestamp();
+        env.storage().persistent().set(&DataKey::NFT(token_id), &nft);
+
+        env.events().publish(
+            (symbol_short!("score_upd"), symbol_short!("nft")),
+            (token_id, new_score),
+        );
     }
 
-    /// Revoke an NFT
+    /// Approve an operator to transfer a specific token on behalf of the owner.
+    ///
+    /// Used by marketplace contracts to facilitate trustless trades.
+    pub fn approve(env: Env, owner: Address, operator: Address, token_id: u64) {
+        owner.require_auth();
+
+        let nft: CreditScoreNFT = env
+            .storage()
+            .persistent()
+            .get(&DataKey::NFT(token_id))
+            .expect("NFT not found");
+
+        if nft.owner != owner {
+            panic!("Only the token owner can approve an operator");
+        }
+
+        if nft.is_revoked {
+            panic!("Cannot approve transfer of a revoked NFT");
+        }
+
+        env.storage().persistent().set(&DataKey::Approved(token_id), &operator);
+
+        env.events().publish(
+            (symbol_short!("approve"), symbol_short!("nft")),
+            (owner, operator, token_id),
+        );
+    }
+
+    /// Revoke a previously set approval.
+    pub fn revoke_approval(env: Env, owner: Address, token_id: u64) {
+        owner.require_auth();
+
+        let nft: CreditScoreNFT = env
+            .storage()
+            .persistent()
+            .get(&DataKey::NFT(token_id))
+            .expect("NFT not found");
+
+        if nft.owner != owner {
+            panic!("Only the token owner can revoke approval");
+        }
+
+        env.storage().persistent().remove(&DataKey::Approved(token_id));
+
+        env.events().publish(
+            (symbol_short!("revk_appr"), symbol_short!("nft")),
+            (owner, token_id),
+        );
+    }
+
+    /// Get the approved operator for a token, if any.
+    pub fn get_approved(env: Env, token_id: u64) -> Option<Address> {
+        env.storage().persistent().get(&DataKey::Approved(token_id))
+    }
+
+    /// Transfer a token to a new owner.
+    ///
+    /// Caller must be either the current owner or an approved operator.
+    pub fn transfer(env: Env, from: Address, to: Address, token_id: u64) {
+        let mut nft: CreditScoreNFT = env
+            .storage()
+            .persistent()
+            .get(&DataKey::NFT(token_id))
+            .expect("NFT not found");
+
+        if nft.is_revoked {
+            panic!("Cannot transfer a revoked NFT");
+        }
+
+        // Caller must be owner or approved operator
+        let approved: Option<Address> = env.storage().persistent().get(&DataKey::Approved(token_id));
+        let caller_is_owner = nft.owner == from;
+        let caller_is_approved = approved.as_ref().map_or(false, |a| *a == from);
+
+        if !caller_is_owner && !caller_is_approved {
+            panic!("Transfer not authorized: caller is not owner or approved operator");
+        }
+
+        from.require_auth();
+
+        // Remove token from previous owner's list
+        let mut from_tokens: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::OwnerTokens(nft.owner.clone()))
+            .unwrap_or(Vec::new(&env));
+        let mut updated_from_tokens: Vec<u64> = Vec::new(&env);
+        for t in from_tokens.iter() {
+            if t != token_id {
+                updated_from_tokens.push_back(t);
+            }
+        }
+        env.storage().persistent().set(&DataKey::OwnerTokens(nft.owner.clone()), &updated_from_tokens);
+
+        // Add token to new owner's list
+        let mut to_tokens: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::OwnerTokens(to.clone()))
+            .unwrap_or(Vec::new(&env));
+        to_tokens.push_back(token_id);
+        env.storage().persistent().set(&DataKey::OwnerTokens(to.clone()), &to_tokens);
+
+        // Clear approval on transfer
+        env.storage().persistent().remove(&DataKey::Approved(token_id));
+
+        // Clear any active listing
+        if env.storage().persistent().has(&DataKey::Listing(token_id)) {
+            env.storage().persistent().remove(&DataKey::Listing(token_id));
+            Self::remove_from_listed_tokens(&env, token_id);
+        }
+
+        nft.owner = to.clone();
+        env.storage().persistent().set(&DataKey::NFT(token_id), &nft);
+
+        env.events().publish(
+            (symbol_short!("transfer"), symbol_short!("nft")),
+            (from, to, token_id),
+        );
+    }
+
+    /// List a token for sale at a given price.
+    pub fn list_for_sale(env: Env, seller: Address, token_id: u64, price: i128) {
+        seller.require_auth();
+
+        if price <= 0 {
+            panic!("Price must be greater than zero");
+        }
+
+        let nft: CreditScoreNFT = env
+            .storage()
+            .persistent()
+            .get(&DataKey::NFT(token_id))
+            .expect("NFT not found");
+
+        if nft.owner != seller {
+            panic!("Only the owner can list a token for sale");
+        }
+
+        if nft.is_revoked {
+            panic!("Cannot list a revoked NFT for sale");
+        }
+
+        let listing = Listing {
+            token_id,
+            seller: seller.clone(),
+            price,
+            listed_at: env.ledger().timestamp(),
+        };
+        env.storage().persistent().set(&DataKey::Listing(token_id), &listing);
+
+        let mut listed: Vec<u64> = env
+            .storage()
+            .instance()
+            .get(&DataKey::ListedTokens)
+            .unwrap_or(Vec::new(&env));
+        // Avoid duplicates
+        let mut already_listed = false;
+        for t in listed.iter() {
+            if t == token_id {
+                already_listed = true;
+                break;
+            }
+        }
+        if !already_listed {
+            listed.push_back(token_id);
+            env.storage().instance().set(&DataKey::ListedTokens, &listed);
+        }
+
+        env.events().publish(
+            (symbol_short!("list"), symbol_short!("nft")),
+            (seller, token_id, price),
+        );
+    }
+
+    /// Delist a token (cancel the sale listing).
+    pub fn delist(env: Env, seller: Address, token_id: u64) {
+        seller.require_auth();
+
+        let listing: Listing = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Listing(token_id))
+            .expect("Token is not listed");
+
+        if listing.seller != seller {
+            panic!("Only the seller can delist");
+        }
+
+        env.storage().persistent().remove(&DataKey::Listing(token_id));
+        Self::remove_from_listed_tokens(&env, token_id);
+
+        env.events().publish(
+            (symbol_short!("delist"), symbol_short!("nft")),
+            (seller, token_id),
+        );
+    }
+
+    /// Buy a listed token. The buyer transfers ownership; price settlement
+    /// is handled off-chain or by the calling contract.
+    ///
+    /// Emits a `buy` event so off-chain indexers can track the trade.
+    pub fn buy(env: Env, buyer: Address, token_id: u64) {
+        buyer.require_auth();
+
+        let listing: Listing = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Listing(token_id))
+            .expect("Token is not listed for sale");
+
+        if buyer == listing.seller {
+            panic!("Seller cannot buy their own listing");
+        }
+
+        // Remove listing before transfer to prevent re-entrancy issues
+        env.storage().persistent().remove(&DataKey::Listing(token_id));
+        Self::remove_from_listed_tokens(&env, token_id);
+
+        // Perform ownership transfer (from seller to buyer)
+        let mut nft: CreditScoreNFT = env
+            .storage()
+            .persistent()
+            .get(&DataKey::NFT(token_id))
+            .unwrap();
+
+        // Update seller's token list
+        let mut seller_tokens: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::OwnerTokens(listing.seller.clone()))
+            .unwrap_or(Vec::new(&env));
+        let mut updated_seller_tokens: Vec<u64> = Vec::new(&env);
+        for t in seller_tokens.iter() {
+            if t != token_id {
+                updated_seller_tokens.push_back(t);
+            }
+        }
+        env.storage().persistent().set(
+            &DataKey::OwnerTokens(listing.seller.clone()),
+            &updated_seller_tokens,
+        );
+
+        // Add to buyer's token list
+        let mut buyer_tokens: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::OwnerTokens(buyer.clone()))
+            .unwrap_or(Vec::new(&env));
+        buyer_tokens.push_back(token_id);
+        env.storage().persistent().set(&DataKey::OwnerTokens(buyer.clone()), &buyer_tokens);
+
+        // Clear approval
+        env.storage().persistent().remove(&DataKey::Approved(token_id));
+
+        nft.owner = buyer.clone();
+        env.storage().persistent().set(&DataKey::NFT(token_id), &nft);
+
+        env.events().publish(
+            (symbol_short!("buy"), symbol_short!("nft")),
+            (buyer, listing.seller, token_id, listing.price),
+        );
+    }
+
+    // ========================================================================
+    // Admin Operations
+    // ========================================================================
+
+    /// Revoke an NFT (admin only).
     pub fn revoke(env: Env, admin: Address, token_id: u64, note: String) {
         admin.require_auth();
         let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
@@ -148,12 +472,15 @@ impl CreditScoreNFTContract {
             .get(&DataKey::NFT(token_id))
             .expect("NFT not found");
 
+        // Remove any active listing when revoking
+        if env.storage().persistent().has(&DataKey::Listing(token_id)) {
+            env.storage().persistent().remove(&DataKey::Listing(token_id));
+            Self::remove_from_listed_tokens(&env, token_id);
+        }
+
         nft.is_revoked = true;
         nft.revocation_note = note.clone();
-
-        env.storage()
-            .persistent()
-            .set(&DataKey::NFT(token_id), &nft);
+        env.storage().persistent().set(&DataKey::NFT(token_id), &nft);
 
         env.events().publish(
             (symbol_short!("revoke"), symbol_short!("nft")),
@@ -161,7 +488,10 @@ impl CreditScoreNFTContract {
         );
     }
 
-    /// Get NFT metadata
+    // ========================================================================
+    // View Functions
+    // ========================================================================
+
     pub fn get_nft(env: Env, token_id: u64) -> CreditScoreNFT {
         env.storage()
             .persistent()
@@ -169,19 +499,21 @@ impl CreditScoreNFTContract {
             .expect("NFT not found")
     }
 
-    /// Get metadata CID for a token
     pub fn get_metadata_cid(env: Env, token_id: u64) -> String {
         let nft: CreditScoreNFT = Self::get_nft(env, token_id);
         nft.metadata_cid
     }
 
-    /// Get owner of a token
     pub fn get_owner(env: Env, token_id: u64) -> Address {
         let nft: CreditScoreNFT = Self::get_nft(env, token_id);
         nft.owner
     }
 
-    /// Get all tokens owned by an address
+    pub fn get_credit_score(env: Env, token_id: u64) -> u32 {
+        let nft: CreditScoreNFT = Self::get_nft(env, token_id);
+        nft.credit_score
+    }
+
     pub fn get_tokens_by_owner(env: Env, owner: Address) -> Vec<u64> {
         env.storage()
             .persistent()
@@ -189,202 +521,233 @@ impl CreditScoreNFTContract {
             .unwrap_or(Vec::new(&env))
     }
 
-    /// Get total supply of NFTs
     pub fn total_supply(env: Env) -> u64 {
         env.storage().instance().get(&DataKey::TokenId).unwrap_or(0)
     }
 
-    /// Get contract admin
     pub fn get_admin(env: Env) -> Address {
         env.storage().instance().get(&DataKey::Admin).unwrap()
     }
+
+    pub fn get_listing(env: Env, token_id: u64) -> Option<Listing> {
+        env.storage().persistent().get(&DataKey::Listing(token_id))
+    }
+
+    pub fn get_listed_tokens(env: Env) -> Vec<u64> {
+        env.storage()
+            .instance()
+            .get(&DataKey::ListedTokens)
+            .unwrap_or(Vec::new(&env))
+    }
+
+    // ========================================================================
+    // Internal
+    // ========================================================================
+
+    fn remove_from_listed_tokens(env: &Env, token_id: u64) {
+        let listed: Vec<u64> = env
+            .storage()
+            .instance()
+            .get(&DataKey::ListedTokens)
+            .unwrap_or(Vec::new(env));
+        let mut updated: Vec<u64> = Vec::new(env);
+        for t in listed.iter() {
+            if t != token_id {
+                updated.push_back(t);
+            }
+        }
+        env.storage().instance().set(&DataKey::ListedTokens, &updated);
+    }
 }
+
+// ============================================================================
+// Tests
+// ============================================================================
 
 #[cfg(test)]
 mod test {
     use super::*;
     use soroban_sdk::{testutils::Address as _, Address, Env, String};
 
-    #[test]
-    fn test_initialize() {
+    fn setup() -> (Env, Address, Address, Address) {
         let env = Env::default();
         env.mock_all_auths();
-
         let contract_id = env.register_contract(None, CreditScoreNFTContract);
         let client = CreditScoreNFTContractClient::new(&env, &contract_id);
-
         let admin = Address::generate(&env);
+        let minter = Address::generate(&env);
         client.initialize(&admin);
+        client.add_minter(&minter);
+        (env, contract_id, admin, minter)
+    }
 
+    #[test]
+    fn test_initialize() {
+        let (env, contract_id, admin, _) = setup();
+        let client = CreditScoreNFTContractClient::new(&env, &contract_id);
         assert_eq!(client.get_admin(), admin);
         assert_eq!(client.total_supply(), 0);
     }
 
     #[test]
-    fn test_add_minter() {
-        let env = Env::default();
-        env.mock_all_auths();
-
-        let contract_id = env.register_contract(None, CreditScoreNFTContract);
+    fn test_add_and_remove_minter() {
+        let (env, contract_id, admin, minter) = setup();
         let client = CreditScoreNFTContractClient::new(&env, &contract_id);
-
-        let admin = Address::generate(&env);
-        let minter = Address::generate(&env);
-
-        client.initialize(&admin);
-        client.add_minter(&minter);
-
         assert!(client.is_minter(&minter));
-    }
-
-    #[test]
-    fn test_mint_nft() {
-        let env = Env::default();
-        env.mock_all_auths();
-
-        let contract_id = env.register_contract(None, CreditScoreNFTContract);
-        let client = CreditScoreNFTContractClient::new(&env, &contract_id);
-
-        let admin = Address::generate(&env);
-        let minter = Address::generate(&env);
-        let recipient = Address::generate(&env);
-
-        client.initialize(&admin);
-        client.add_minter(&minter);
-
-        let metadata = String::from_str(&env, "QmXYZ123...");
-        let token_id = client.mint(&minter, &recipient, &metadata);
-
-        assert_eq!(token_id, 1);
-        assert_eq!(client.get_owner(&token_id), recipient);
-        assert_eq!(client.get_metadata_cid(&token_id), metadata);
-        assert_eq!(client.total_supply(), 1);
-        
-        let nft = client.get_nft(&token_id);
-        assert!(!nft.is_revoked);
-    }
-
-    #[test]
-    #[should_panic(expected = "Credit Score NFTs are non-transferable (soulbound)")]
-    fn test_transfer_nft_fails() {
-        let env = Env::default();
-        env.mock_all_auths();
-
-        let contract_id = env.register_contract(None, CreditScoreNFTContract);
-        let client = CreditScoreNFTContractClient::new(&env, &contract_id);
-
-        let admin = Address::generate(&env);
-        let minter = Address::generate(&env);
-        let owner = Address::generate(&env);
-        let recipient = Address::generate(&env);
-
-        client.initialize(&admin);
-        client.add_minter(&minter);
-
-        let metadata = String::from_str(&env, "QmXYZ123...");
-        let token_id = client.mint(&minter, &owner, &metadata);
-
-        client.transfer(&owner, &recipient, &token_id);
-    }
-
-    #[test]
-    #[should_panic(expected = "Unauthorized: caller is not an authorized minter")]
-    fn test_mint_unauthorized() {
-        let env = Env::default();
-        env.mock_all_auths();
-
-        let contract_id = env.register_contract(None, CreditScoreNFTContract);
-        let client = CreditScoreNFTContractClient::new(&env, &contract_id);
-
-        let admin = Address::generate(&env);
-        let unauthorized = Address::generate(&env);
-        let recipient = Address::generate(&env);
-
-        client.initialize(&admin);
-
-        let metadata = String::from_str(&env, "QmXYZ123...");
-        client.mint(&unauthorized, &recipient, &metadata);
-    }
-
-    #[test]
-    fn test_admin_can_mint() {
-        let env = Env::default();
-        env.mock_all_auths();
-
-        let contract_id = env.register_contract(None, CreditScoreNFTContract);
-        let client = CreditScoreNFTContractClient::new(&env, &contract_id);
-
-        let admin = Address::generate(&env);
-        let recipient = Address::generate(&env);
-
-        client.initialize(&admin);
-
-        let metadata = String::from_str(&env, "QmABC456...");
-        let token_id = client.mint(&admin, &recipient, &metadata);
-
-        assert_eq!(token_id, 1);
-        assert_eq!(client.get_owner(&token_id), recipient);
-    }
-
-    #[test]
-    fn test_remove_minter() {
-        let env = Env::default();
-        env.mock_all_auths();
-
-        let contract_id = env.register_contract(None, CreditScoreNFTContract);
-        let client = CreditScoreNFTContractClient::new(&env, &contract_id);
-
-        let admin = Address::generate(&env);
-        let minter = Address::generate(&env);
-
-        client.initialize(&admin);
-        client.add_minter(&minter);
-        assert!(client.is_minter(&minter));
-
         client.remove_minter(&minter);
         assert!(!client.is_minter(&minter));
     }
 
     #[test]
-    fn test_multiple_mints() {
-        let env = Env::default();
-        env.mock_all_auths();
-
-        let contract_id = env.register_contract(None, CreditScoreNFTContract);
+    fn test_mint_nft_with_credit_score() {
+        let (env, contract_id, _, minter) = setup();
         let client = CreditScoreNFTContractClient::new(&env, &contract_id);
-
-        let admin = Address::generate(&env);
-        let minter = Address::generate(&env);
         let recipient = Address::generate(&env);
 
-        client.initialize(&admin);
-        client.add_minter(&minter);
+        let metadata = String::from_str(&env, "QmXYZ123...");
+        let token_id = client.mint(&minter, &recipient, &metadata, &750);
 
-        let metadata1 = String::from_str(&env, "QmFirst...");
-        let token_id1 = client.mint(&minter, &recipient, &metadata1);
+        assert_eq!(token_id, 1);
+        assert_eq!(client.get_owner(&token_id), recipient);
+        assert_eq!(client.get_credit_score(&token_id), 750);
+        assert_eq!(client.get_metadata_cid(&token_id), metadata);
+        assert_eq!(client.total_supply(), 1);
 
-        let metadata2 = String::from_str(&env, "QmSecond...");
-        let token_id2 = client.mint(&minter, &recipient, &metadata2);
+        let nft = client.get_nft(&token_id);
+        assert!(!nft.is_revoked);
+        assert_eq!(nft.credit_score, 750);
+    }
 
-        assert_eq!(token_id1, 1);
-        assert_eq!(token_id2, 2);
-        assert_eq!(client.total_supply(), 2);
+    #[test]
+    fn test_admin_can_mint() {
+        let (env, contract_id, admin, _) = setup();
+        let client = CreditScoreNFTContractClient::new(&env, &contract_id);
+        let recipient = Address::generate(&env);
+
+        let metadata = String::from_str(&env, "QmABC456...");
+        let token_id = client.mint(&admin, &recipient, &metadata, &600);
+        assert_eq!(token_id, 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "Unauthorized: caller is not an authorized minter")]
+    fn test_mint_unauthorized() {
+        let (env, contract_id, _, _) = setup();
+        let client = CreditScoreNFTContractClient::new(&env, &contract_id);
+        let unauthorized = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        let metadata = String::from_str(&env, "QmXYZ123...");
+        client.mint(&unauthorized, &recipient, &metadata, &500);
+    }
+
+    #[test]
+    fn test_update_credit_score() {
+        let (env, contract_id, _, minter) = setup();
+        let client = CreditScoreNFTContractClient::new(&env, &contract_id);
+        let recipient = Address::generate(&env);
+
+        let metadata = String::from_str(&env, "QmScore...");
+        let token_id = client.mint(&minter, &recipient, &metadata, &600);
+        assert_eq!(client.get_credit_score(&token_id), 600);
+
+        client.update_credit_score(&minter, &token_id, &750);
+        assert_eq!(client.get_credit_score(&token_id), 750);
+    }
+
+    #[test]
+    fn test_transfer_with_approval() {
+        let (env, contract_id, _, minter) = setup();
+        let client = CreditScoreNFTContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let operator = Address::generate(&env);
+        let recipient = Address::generate(&env);
+
+        let metadata = String::from_str(&env, "QmXYZ...");
+        let token_id = client.mint(&minter, &owner, &metadata, &700);
+
+        // Owner approves operator
+        client.approve(&owner, &operator, &token_id);
+        assert_eq!(client.get_approved(&token_id).unwrap(), operator);
+
+        // Operator transfers token to recipient
+        client.transfer(&operator, &recipient, &token_id);
+        assert_eq!(client.get_owner(&token_id), recipient);
+
+        // Approval cleared after transfer
+        assert!(client.get_approved(&token_id).is_none());
+
+        // Owner's token list updated
+        let owner_tokens = client.get_tokens_by_owner(&owner);
+        assert_eq!(owner_tokens.len(), 0);
+        let recipient_tokens = client.get_tokens_by_owner(&recipient);
+        assert_eq!(recipient_tokens.len(), 1);
+    }
+
+    #[test]
+    fn test_owner_can_transfer_directly() {
+        let (env, contract_id, _, minter) = setup();
+        let client = CreditScoreNFTContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let recipient = Address::generate(&env);
+
+        let metadata = String::from_str(&env, "QmOwner...");
+        let token_id = client.mint(&minter, &owner, &metadata, &800);
+
+        client.transfer(&owner, &recipient, &token_id);
+        assert_eq!(client.get_owner(&token_id), recipient);
+    }
+
+    #[test]
+    fn test_marketplace_list_and_buy() {
+        let (env, contract_id, _, minter) = setup();
+        let client = CreditScoreNFTContractClient::new(&env, &contract_id);
+
+        let seller = Address::generate(&env);
+        let buyer = Address::generate(&env);
+
+        let metadata = String::from_str(&env, "QmMarket...");
+        let token_id = client.mint(&minter, &seller, &metadata, &900);
+
+        // Seller lists the token
+        client.list_for_sale(&seller, &token_id, &5_000_000);
+        let listing = client.get_listing(&token_id).unwrap();
+        assert_eq!(listing.price, 5_000_000);
+        assert_eq!(client.get_listed_tokens().len(), 1);
+
+        // Buyer purchases
+        client.buy(&buyer, &token_id);
+        assert_eq!(client.get_owner(&token_id), buyer);
+        assert!(client.get_listing(&token_id).is_none());
+        assert_eq!(client.get_listed_tokens().len(), 0);
+    }
+
+    #[test]
+    fn test_delist() {
+        let (env, contract_id, _, minter) = setup();
+        let client = CreditScoreNFTContractClient::new(&env, &contract_id);
+
+        let seller = Address::generate(&env);
+        let metadata = String::from_str(&env, "QmDelist...");
+        let token_id = client.mint(&minter, &seller, &metadata, &500);
+
+        client.list_for_sale(&seller, &token_id, &1_000_000);
+        assert!(client.get_listing(&token_id).is_some());
+
+        client.delist(&seller, &token_id);
+        assert!(client.get_listing(&token_id).is_none());
+        assert_eq!(client.get_listed_tokens().len(), 0);
+    }
 
     #[test]
     fn test_revoke_nft() {
-        let env = Env::default();
-        env.mock_all_auths();
-
-        let contract_id = env.register_contract(None, CreditScoreNFTContract);
+        let (env, contract_id, admin, minter) = setup();
         let client = CreditScoreNFTContractClient::new(&env, &contract_id);
 
-        let admin = Address::generate(&env);
         let recipient = Address::generate(&env);
-
-        client.initialize(&admin);
-
-        let metadata = String::from_str(&env, "QmScore...");
-        let token_id = client.mint(&admin, &recipient, &metadata);
+        let metadata = String::from_str(&env, "QmRevoke...");
+        let token_id = client.mint(&minter, &recipient, &metadata, &400);
 
         let note = String::from_str(&env, "Fraud detected");
         client.revoke(&admin, &token_id, &note);
@@ -392,5 +755,25 @@ mod test {
         let nft = client.get_nft(&token_id);
         assert!(nft.is_revoked);
         assert_eq!(nft.revocation_note, note);
+    }
+
+    #[test]
+    fn test_multiple_mints() {
+        let (env, contract_id, _, minter) = setup();
+        let client = CreditScoreNFTContractClient::new(&env, &contract_id);
+        let recipient = Address::generate(&env);
+
+        let metadata1 = String::from_str(&env, "QmFirst...");
+        let token_id1 = client.mint(&minter, &recipient, &metadata1, &600);
+
+        let metadata2 = String::from_str(&env, "QmSecond...");
+        let token_id2 = client.mint(&minter, &recipient, &metadata2, &700);
+
+        assert_eq!(token_id1, 1);
+        assert_eq!(token_id2, 2);
+        assert_eq!(client.total_supply(), 2);
+
+        let tokens = client.get_tokens_by_owner(&recipient);
+        assert_eq!(tokens.len(), 2);
     }
 }

--- a/contracts/referral-rewards/Cargo.toml
+++ b/contracts/referral-rewards/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "referral-rewards"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { version = "21.0.0" }
+common-utils = { path = "../common-utils/contract" }
+
+[dev-dependencies]
+soroban-sdk = { version = "21.0.0", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true

--- a/contracts/referral-rewards/src/lib.rs
+++ b/contracts/referral-rewards/src/lib.rs
@@ -1,0 +1,540 @@
+//! # Referral Rewards Contract
+//!
+//! On-chain referral tracking with fraud-proof reward distribution.
+//!
+//! ## Features
+//!
+//! - **On-chain Referral Tracking**: All referral relationships stored on-chain
+//! - **Reward Minting**: Admin mints reward tokens to the reward pool
+//! - **Event-Driven**: Every referral and reward action emits an event
+//! - **Fraud-Proof**: Prevents self-referral and duplicate referrals
+//! - **Secure Distribution**: Rewards only claimable by verified referrers
+//!
+//! ## Flow
+//!
+//! 1. Admin initializes contract and funds reward pool
+//! 2. User registers with a referrer address
+//! 3. Admin confirms the referral (fraud check gate)
+//! 4. Referrer accumulates reward balance
+//! 5. Referrer claims their reward tokens
+
+#![no_std]
+
+use soroban_sdk::{
+    contract, contractimpl, contracttype, symbol_short,
+    Address, Env, Vec,
+};
+use common_utils::error::CommonError;
+
+// ============================================================================
+// Storage Keys
+// ============================================================================
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Initialized,
+    Config,
+
+    // Referral relationships
+    ReferredBy(Address),           // user → referrer
+    ReferralCount(Address),        // referrer → count of confirmed referrals
+    ReferralList(Address),         // referrer → Vec<Address> of referees
+
+    // Reward balances
+    PendingReward(Address),        // referrer → claimable reward amount
+    TotalClaimed(Address),         // referrer → lifetime claimed amount
+
+    // Anti-fraud: track confirmed vs pending referrals
+    ReferralStatus(Address),       // user → ReferralStatus
+
+    // Global stats
+    RewardPool,
+    TotalReferrals,
+    TotalRewardsPaid,
+}
+
+// ============================================================================
+// Data Types
+// ============================================================================
+
+/// Status of a referral registration
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[contracttype]
+pub enum ReferralStatus {
+    /// Registered but awaiting admin confirmation
+    Pending = 0,
+    /// Confirmed and reward issued to referrer
+    Confirmed = 1,
+    /// Rejected (fraud detected)
+    Rejected = 2,
+}
+
+/// Contract-level configuration
+#[derive(Clone)]
+#[contracttype]
+pub struct RewardConfig {
+    /// Fixed reward per confirmed referral (in reward token units)
+    pub reward_per_referral: i128,
+    /// Maximum referrals a single address can make (anti-spam)
+    pub max_referrals_per_address: u32,
+    pub paused: bool,
+}
+
+/// Snapshot of a referral record for queries
+#[derive(Clone)]
+#[contracttype]
+pub struct ReferralRecord {
+    pub referee: Address,
+    pub referrer: Address,
+    pub status: ReferralStatus,
+    pub registered_at: u64,
+    pub confirmed_at: u64,
+}
+
+// ============================================================================
+// Contract
+// ============================================================================
+
+#[contract]
+pub struct ReferralRewardsContract;
+
+#[contractimpl]
+impl ReferralRewardsContract {
+    /// Initialize the contract.
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        reward_per_referral: i128,
+        max_referrals_per_address: u32,
+    ) -> Result<(), CommonError> {
+        if env.storage().instance().has(&DataKey::Initialized) {
+            return Err(CommonError::AlreadyInitialized);
+        }
+
+        admin.require_auth();
+
+        if reward_per_referral <= 0 {
+            return Err(CommonError::OutOfRange);
+        }
+
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::Config, &RewardConfig {
+            reward_per_referral,
+            max_referrals_per_address: if max_referrals_per_address == 0 { 100 } else { max_referrals_per_address },
+            paused: false,
+        });
+        env.storage().instance().set(&DataKey::RewardPool, &0i128);
+        env.storage().instance().set(&DataKey::TotalReferrals, &0u64);
+        env.storage().instance().set(&DataKey::TotalRewardsPaid, &0i128);
+        env.storage().instance().set(&DataKey::Initialized, &true);
+
+        env.events().publish(
+            (symbol_short!("rr_init"), admin),
+            (reward_per_referral, max_referrals_per_address),
+        );
+
+        Ok(())
+    }
+
+    /// Admin funds the reward pool.
+    pub fn fund_pool(env: Env, admin: Address, amount: i128) -> Result<(), CommonError> {
+        Self::require_admin(&env, &admin)?;
+
+        if amount <= 0 {
+            return Err(CommonError::OutOfRange);
+        }
+
+        let mut pool: i128 = env.storage().instance().get(&DataKey::RewardPool).unwrap_or(0);
+        pool += amount;
+        env.storage().instance().set(&DataKey::RewardPool, &pool);
+
+        env.events().publish(
+            (symbol_short!("rr_fund"), admin),
+            (amount, pool),
+        );
+
+        Ok(())
+    }
+
+    /// Register a referral relationship.
+    ///
+    /// Fraud checks enforced:
+    /// - A user cannot refer themselves
+    /// - A user can only be referred once
+    /// - The referrer must not exceed `max_referrals_per_address`
+    pub fn register_referral(
+        env: Env,
+        referee: Address,
+        referrer: Address,
+    ) -> Result<(), CommonError> {
+        referee.require_auth();
+
+        let config: RewardConfig = env.storage().instance().get(&DataKey::Config).unwrap();
+        if config.paused {
+            return Err(CommonError::NotAuthorized);
+        }
+
+        // Self-referral check
+        if referee == referrer {
+            return Err(CommonError::NotAuthorized);
+        }
+
+        // Duplicate referral check
+        if env.storage().persistent().has(&DataKey::ReferredBy(referee.clone())) {
+            return Err(CommonError::AlreadyInitialized);
+        }
+
+        // Referrer cap check
+        let ref_count: u32 = env.storage().persistent()
+            .get(&DataKey::ReferralCount(referrer.clone()))
+            .unwrap_or(0);
+        if ref_count >= config.max_referrals_per_address {
+            return Err(CommonError::OutOfRange);
+        }
+
+        // Record relationship as pending
+        env.storage().persistent().set(&DataKey::ReferredBy(referee.clone()), &referrer);
+        env.storage().persistent().set(
+            &DataKey::ReferralStatus(referee.clone()),
+            &ReferralStatus::Pending,
+        );
+
+        // Append to referrer's referee list
+        let mut list: Vec<Address> = env.storage().persistent()
+            .get(&DataKey::ReferralList(referrer.clone()))
+            .unwrap_or_else(|| Vec::new(&env));
+        list.push_back(referee.clone());
+        env.storage().persistent().set(&DataKey::ReferralList(referrer.clone()), &list);
+
+        let total: u64 = env.storage().instance().get(&DataKey::TotalReferrals).unwrap_or(0);
+        env.storage().instance().set(&DataKey::TotalReferrals, &(total + 1));
+
+        env.events().publish(
+            (symbol_short!("rr_reg"), referee.clone()),
+            (referrer, symbol_short!("pending")),
+        );
+
+        Ok(())
+    }
+
+    /// Admin confirms a referral and credits the referrer's reward balance.
+    pub fn confirm_referral(env: Env, admin: Address, referee: Address) -> Result<i128, CommonError> {
+        Self::require_admin(&env, &admin)?;
+
+        let status: ReferralStatus = env.storage().persistent()
+            .get(&DataKey::ReferralStatus(referee.clone()))
+            .ok_or(CommonError::KeyNotFound)?;
+
+        if status != ReferralStatus::Pending {
+            return Err(CommonError::AlreadyInitialized);
+        }
+
+        let referrer: Address = env.storage().persistent()
+            .get(&DataKey::ReferredBy(referee.clone()))
+            .ok_or(CommonError::KeyNotFound)?;
+
+        let config: RewardConfig = env.storage().instance().get(&DataKey::Config).unwrap();
+
+        // Check pool solvency
+        let mut pool: i128 = env.storage().instance().get(&DataKey::RewardPool).unwrap_or(0);
+        if pool < config.reward_per_referral {
+            return Err(CommonError::OutOfRange);
+        }
+        pool -= config.reward_per_referral;
+        env.storage().instance().set(&DataKey::RewardPool, &pool);
+
+        // Credit referrer
+        let mut pending: i128 = env.storage().persistent()
+            .get(&DataKey::PendingReward(referrer.clone()))
+            .unwrap_or(0);
+        pending += config.reward_per_referral;
+        env.storage().persistent().set(&DataKey::PendingReward(referrer.clone()), &pending);
+
+        // Update referral count
+        let mut count: u32 = env.storage().persistent()
+            .get(&DataKey::ReferralCount(referrer.clone()))
+            .unwrap_or(0);
+        count += 1;
+        env.storage().persistent().set(&DataKey::ReferralCount(referrer.clone()), &count);
+
+        // Mark confirmed
+        env.storage().persistent().set(
+            &DataKey::ReferralStatus(referee.clone()),
+            &ReferralStatus::Confirmed,
+        );
+
+        env.events().publish(
+            (symbol_short!("rr_conf"), referee),
+            (referrer, config.reward_per_referral),
+        );
+
+        Ok(config.reward_per_referral)
+    }
+
+    /// Admin rejects a referral (fraud detected).
+    pub fn reject_referral(env: Env, admin: Address, referee: Address) -> Result<(), CommonError> {
+        Self::require_admin(&env, &admin)?;
+
+        let status: ReferralStatus = env.storage().persistent()
+            .get(&DataKey::ReferralStatus(referee.clone()))
+            .ok_or(CommonError::KeyNotFound)?;
+
+        if status != ReferralStatus::Pending {
+            return Err(CommonError::AlreadyInitialized);
+        }
+
+        env.storage().persistent().set(
+            &DataKey::ReferralStatus(referee.clone()),
+            &ReferralStatus::Rejected,
+        );
+
+        env.events().publish(
+            (symbol_short!("rr_rej"), admin),
+            referee,
+        );
+
+        Ok(())
+    }
+
+    /// Referrer claims their accumulated reward.
+    pub fn claim_reward(env: Env, referrer: Address) -> Result<i128, CommonError> {
+        referrer.require_auth();
+
+        let pending: i128 = env.storage().persistent()
+            .get(&DataKey::PendingReward(referrer.clone()))
+            .unwrap_or(0);
+
+        if pending <= 0 {
+            return Err(CommonError::OutOfRange);
+        }
+
+        env.storage().persistent().set(&DataKey::PendingReward(referrer.clone()), &0i128);
+
+        let mut total_claimed: i128 = env.storage().persistent()
+            .get(&DataKey::TotalClaimed(referrer.clone()))
+            .unwrap_or(0);
+        total_claimed += pending;
+        env.storage().persistent().set(&DataKey::TotalClaimed(referrer.clone()), &total_claimed);
+
+        let mut total_paid: i128 = env.storage().instance().get(&DataKey::TotalRewardsPaid).unwrap_or(0);
+        total_paid += pending;
+        env.storage().instance().set(&DataKey::TotalRewardsPaid, &total_paid);
+
+        env.events().publish(
+            (symbol_short!("rr_claim"), referrer),
+            (pending, total_claimed),
+        );
+
+        Ok(pending)
+    }
+
+    // ========================================================================
+    // View Functions
+    // ========================================================================
+
+    pub fn get_pending_reward(env: Env, referrer: Address) -> i128 {
+        env.storage().persistent().get(&DataKey::PendingReward(referrer)).unwrap_or(0)
+    }
+
+    pub fn get_referrer(env: Env, referee: Address) -> Option<Address> {
+        env.storage().persistent().get(&DataKey::ReferredBy(referee))
+    }
+
+    pub fn get_referral_status(env: Env, referee: Address) -> Option<ReferralStatus> {
+        env.storage().persistent().get(&DataKey::ReferralStatus(referee))
+    }
+
+    pub fn get_referral_count(env: Env, referrer: Address) -> u32 {
+        env.storage().persistent().get(&DataKey::ReferralCount(referrer)).unwrap_or(0)
+    }
+
+    pub fn get_referral_list(env: Env, referrer: Address) -> Vec<Address> {
+        env.storage().persistent()
+            .get(&DataKey::ReferralList(referrer))
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    pub fn get_reward_pool(env: Env) -> i128 {
+        env.storage().instance().get(&DataKey::RewardPool).unwrap_or(0)
+    }
+
+    pub fn get_total_referrals(env: Env) -> u64 {
+        env.storage().instance().get(&DataKey::TotalReferrals).unwrap_or(0)
+    }
+
+    pub fn get_total_rewards_paid(env: Env) -> i128 {
+        env.storage().instance().get(&DataKey::TotalRewardsPaid).unwrap_or(0)
+    }
+
+    // ========================================================================
+    // Admin
+    // ========================================================================
+
+    pub fn set_paused(env: Env, admin: Address, paused: bool) -> Result<(), CommonError> {
+        Self::require_admin(&env, &admin)?;
+        let mut config: RewardConfig = env.storage().instance().get(&DataKey::Config).unwrap();
+        config.paused = paused;
+        env.storage().instance().set(&DataKey::Config, &config);
+        Ok(())
+    }
+
+    pub fn update_reward_per_referral(env: Env, admin: Address, new_reward: i128) -> Result<(), CommonError> {
+        Self::require_admin(&env, &admin)?;
+        if new_reward <= 0 {
+            return Err(CommonError::OutOfRange);
+        }
+        let mut config: RewardConfig = env.storage().instance().get(&DataKey::Config).unwrap();
+        config.reward_per_referral = new_reward;
+        env.storage().instance().set(&DataKey::Config, &config);
+        Ok(())
+    }
+
+    // ========================================================================
+    // Internal
+    // ========================================================================
+
+    fn require_admin(env: &Env, caller: &Address) -> Result<(), CommonError> {
+        let admin: Address = env.storage().instance()
+            .get(&DataKey::Admin)
+            .ok_or(CommonError::NotInitialized)?;
+
+        if admin != *caller {
+            return Err(CommonError::NotAuthorized);
+        }
+
+        caller.require_auth();
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env};
+
+    fn setup(reward_per_referral: i128) -> (Env, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, ReferralRewardsContract);
+        let client = ReferralRewardsContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin, &reward_per_referral, &10).unwrap();
+        (env, contract_id, admin)
+    }
+
+    #[test]
+    fn test_initialize() {
+        let (env, contract_id, _) = setup(1_000_000);
+        let client = ReferralRewardsContractClient::new(&env, &contract_id);
+        assert_eq!(client.get_reward_pool(), 0);
+        assert_eq!(client.get_total_referrals(), 0);
+    }
+
+    #[test]
+    fn test_fund_pool() {
+        let (env, contract_id, admin) = setup(1_000_000);
+        let client = ReferralRewardsContractClient::new(&env, &contract_id);
+        client.fund_pool(&admin, &10_000_000).unwrap();
+        assert_eq!(client.get_reward_pool(), 10_000_000);
+    }
+
+    #[test]
+    fn test_register_referral() {
+        let (env, contract_id, admin) = setup(1_000_000);
+        let client = ReferralRewardsContractClient::new(&env, &contract_id);
+
+        let referrer = Address::generate(&env);
+        let referee = Address::generate(&env);
+
+        client.register_referral(&referee, &referrer).unwrap();
+
+        assert_eq!(client.get_referrer(&referee).unwrap(), referrer);
+        assert_eq!(client.get_referral_status(&referee).unwrap(), ReferralStatus::Pending);
+        assert_eq!(client.get_total_referrals(), 1);
+    }
+
+    #[test]
+    fn test_self_referral_fails() {
+        let (env, contract_id, _) = setup(1_000_000);
+        let client = ReferralRewardsContractClient::new(&env, &contract_id);
+        let user = Address::generate(&env);
+        assert!(client.try_register_referral(&user, &user).is_err());
+    }
+
+    #[test]
+    fn test_duplicate_referral_fails() {
+        let (env, contract_id, _) = setup(1_000_000);
+        let client = ReferralRewardsContractClient::new(&env, &contract_id);
+        let referrer = Address::generate(&env);
+        let referee = Address::generate(&env);
+
+        client.register_referral(&referee, &referrer).unwrap();
+        assert!(client.try_register_referral(&referee, &referrer).is_err());
+    }
+
+    #[test]
+    fn test_confirm_referral_credits_referrer() {
+        let (env, contract_id, admin) = setup(1_000_000);
+        let client = ReferralRewardsContractClient::new(&env, &contract_id);
+
+        client.fund_pool(&admin, &10_000_000).unwrap();
+
+        let referrer = Address::generate(&env);
+        let referee = Address::generate(&env);
+
+        client.register_referral(&referee, &referrer).unwrap();
+        let reward = client.confirm_referral(&admin, &referee).unwrap();
+
+        assert_eq!(reward, 1_000_000);
+        assert_eq!(client.get_pending_reward(&referrer), 1_000_000);
+        assert_eq!(client.get_referral_status(&referee).unwrap(), ReferralStatus::Confirmed);
+        assert_eq!(client.get_referral_count(&referrer), 1);
+    }
+
+    #[test]
+    fn test_reject_referral() {
+        let (env, contract_id, admin) = setup(1_000_000);
+        let client = ReferralRewardsContractClient::new(&env, &contract_id);
+
+        let referrer = Address::generate(&env);
+        let referee = Address::generate(&env);
+
+        client.register_referral(&referee, &referrer).unwrap();
+        client.reject_referral(&admin, &referee).unwrap();
+
+        assert_eq!(client.get_referral_status(&referee).unwrap(), ReferralStatus::Rejected);
+        assert_eq!(client.get_pending_reward(&referrer), 0);
+    }
+
+    #[test]
+    fn test_claim_reward() {
+        let (env, contract_id, admin) = setup(1_000_000);
+        let client = ReferralRewardsContractClient::new(&env, &contract_id);
+
+        client.fund_pool(&admin, &10_000_000).unwrap();
+
+        let referrer = Address::generate(&env);
+        let referee = Address::generate(&env);
+
+        client.register_referral(&referee, &referrer).unwrap();
+        client.confirm_referral(&admin, &referee).unwrap();
+
+        let claimed = client.claim_reward(&referrer).unwrap();
+        assert_eq!(claimed, 1_000_000);
+        assert_eq!(client.get_pending_reward(&referrer), 0);
+        assert_eq!(client.get_total_rewards_paid(), 1_000_000);
+    }
+
+    #[test]
+    fn test_claim_with_no_reward_fails() {
+        let (env, contract_id, _) = setup(1_000_000);
+        let client = ReferralRewardsContractClient::new(&env, &contract_id);
+        let referrer = Address::generate(&env);
+        assert!(client.try_claim_reward(&referrer).is_err());
+    }
+}

--- a/contracts/staking-bonuses/Cargo.toml
+++ b/contracts/staking-bonuses/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "staking-bonuses"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { version = "21.0.0" }
+common-utils = { path = "../common-utils/contract" }
+
+[dev-dependencies]
+soroban-sdk = { version = "21.0.0", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true

--- a/contracts/staking-bonuses/src/lib.rs
+++ b/contracts/staking-bonuses/src/lib.rs
@@ -1,0 +1,473 @@
+//! # Staking Bonuses Contract
+//!
+//! Duration-based staking bonuses with time locks and periodic claimable rewards.
+//!
+//! ## Features
+//!
+//! - **Duration Tiers**: Longer lock periods earn higher bonus rates
+//! - **Time Locks**: Staked tokens are locked until the end of the chosen period
+//! - **Claimable Bonuses**: Accumulated bonuses can be claimed after the lock expires
+//! - **Transparent**: All stake/bonus events are emitted on-chain
+//! - **Admin Controls**: Configurable bonus rates and reward pool management
+
+#![no_std]
+
+use soroban_sdk::{
+    contract, contractimpl, contracttype, symbol_short,
+    Address, Env, Vec,
+};
+use common_utils::error::CommonError;
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const SECONDS_PER_DAY: u64 = 86_400;
+
+/// Bonus rate (basis points) for each tier
+const TIER1_RATE_BPS: u32 = 500;   // 5%  — 30 days
+const TIER2_RATE_BPS: u32 = 1000;  // 10% — 90 days
+const TIER3_RATE_BPS: u32 = 1500;  // 15% — 180 days
+const TIER4_RATE_BPS: u32 = 2500;  // 25% — 365 days
+
+const TIER1_DAYS: u64 = 30;
+const TIER2_DAYS: u64 = 90;
+const TIER3_DAYS: u64 = 180;
+const TIER4_DAYS: u64 = 365;
+
+// ============================================================================
+// Storage Keys
+// ============================================================================
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Initialized,
+    Config,
+
+    // Per-user stake records
+    Stake(Address),
+
+    // Reward pool (deposited by admin)
+    RewardPool,
+
+    // Global stats
+    TotalStaked,
+    TotalBonusPaid,
+    StakeCount,
+}
+
+// ============================================================================
+// Data Types
+// ============================================================================
+
+/// Lock tier chosen by the staker
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[contracttype]
+pub enum LockTier {
+    Days30 = 0,
+    Days90 = 1,
+    Days180 = 2,
+    Days365 = 3,
+}
+
+impl LockTier {
+    pub fn duration_seconds(self) -> u64 {
+        match self {
+            LockTier::Days30  => TIER1_DAYS  * SECONDS_PER_DAY,
+            LockTier::Days90  => TIER2_DAYS  * SECONDS_PER_DAY,
+            LockTier::Days180 => TIER3_DAYS  * SECONDS_PER_DAY,
+            LockTier::Days365 => TIER4_DAYS  * SECONDS_PER_DAY,
+        }
+    }
+
+    pub fn bonus_rate_bps(self) -> u32 {
+        match self {
+            LockTier::Days30  => TIER1_RATE_BPS,
+            LockTier::Days90  => TIER2_RATE_BPS,
+            LockTier::Days180 => TIER3_RATE_BPS,
+            LockTier::Days365 => TIER4_RATE_BPS,
+        }
+    }
+}
+
+/// Active stake record for a user
+#[derive(Clone)]
+#[contracttype]
+pub struct StakeRecord {
+    pub staker: Address,
+    pub amount: i128,
+    pub tier: LockTier,
+    pub staked_at: u64,
+    pub lock_until: u64,
+    pub bonus_amount: i128,
+    pub claimed: bool,
+}
+
+/// Contract configuration
+#[derive(Clone)]
+#[contracttype]
+pub struct StakingConfig {
+    pub min_stake: i128,
+    pub paused: bool,
+}
+
+// ============================================================================
+// Contract
+// ============================================================================
+
+#[contract]
+pub struct StakingBonusesContract;
+
+#[contractimpl]
+impl StakingBonusesContract {
+    /// Initialize the contract.
+    pub fn initialize(env: Env, admin: Address) -> Result<(), CommonError> {
+        if env.storage().instance().has(&DataKey::Initialized) {
+            return Err(CommonError::AlreadyInitialized);
+        }
+
+        admin.require_auth();
+
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::Config, &StakingConfig {
+            min_stake: 1_000_000,
+            paused: false,
+        });
+        env.storage().instance().set(&DataKey::RewardPool, &0i128);
+        env.storage().instance().set(&DataKey::TotalStaked, &0i128);
+        env.storage().instance().set(&DataKey::TotalBonusPaid, &0i128);
+        env.storage().instance().set(&DataKey::StakeCount, &0u64);
+        env.storage().instance().set(&DataKey::Initialized, &true);
+
+        env.events().publish(
+            (symbol_short!("sb_init"), admin),
+            symbol_short!("ok"),
+        );
+
+        Ok(())
+    }
+
+    /// Deposit tokens into the reward pool (admin only).
+    pub fn fund_reward_pool(env: Env, admin: Address, amount: i128) -> Result<(), CommonError> {
+        Self::require_admin(&env, &admin)?;
+
+        if amount <= 0 {
+            return Err(CommonError::OutOfRange);
+        }
+
+        let mut pool: i128 = env.storage().instance().get(&DataKey::RewardPool).unwrap_or(0);
+        pool += amount;
+        env.storage().instance().set(&DataKey::RewardPool, &pool);
+
+        env.events().publish(
+            (symbol_short!("sb_fund"), admin),
+            (amount, pool),
+        );
+
+        Ok(())
+    }
+
+    /// Stake tokens for a given lock tier.
+    ///
+    /// The bonus is calculated immediately at stake time and reserved from the pool.
+    /// Tokens + bonus become claimable once `lock_until` passes.
+    pub fn stake(env: Env, staker: Address, amount: i128, tier: LockTier) -> Result<i128, CommonError> {
+        staker.require_auth();
+
+        let config: StakingConfig = env.storage().instance().get(&DataKey::Config).unwrap();
+        if config.paused {
+            return Err(CommonError::NotAuthorized);
+        }
+
+        if amount < config.min_stake {
+            return Err(CommonError::OutOfRange);
+        }
+
+        // Prevent a second stake from the same address while one is active
+        if env.storage().persistent().has(&DataKey::Stake(staker.clone())) {
+            let existing: StakeRecord = env.storage().persistent()
+                .get(&DataKey::Stake(staker.clone())).unwrap();
+            if !existing.claimed {
+                return Err(CommonError::AlreadyInitialized);
+            }
+        }
+
+        let bonus_amount = (amount * tier.bonus_rate_bps() as i128) / 10_000;
+
+        // Ensure reward pool can cover the bonus
+        let mut pool: i128 = env.storage().instance().get(&DataKey::RewardPool).unwrap_or(0);
+        if pool < bonus_amount {
+            return Err(CommonError::OutOfRange);
+        }
+        pool -= bonus_amount;
+        env.storage().instance().set(&DataKey::RewardPool, &pool);
+
+        let now = env.ledger().timestamp();
+        let lock_until = now + tier.duration_seconds();
+
+        let record = StakeRecord {
+            staker: staker.clone(),
+            amount,
+            tier,
+            staked_at: now,
+            lock_until,
+            bonus_amount,
+            claimed: false,
+        };
+        env.storage().persistent().set(&DataKey::Stake(staker.clone()), &record);
+
+        let mut total_staked: i128 = env.storage().instance().get(&DataKey::TotalStaked).unwrap_or(0);
+        total_staked += amount;
+        env.storage().instance().set(&DataKey::TotalStaked, &total_staked);
+
+        let count: u64 = env.storage().instance().get(&DataKey::StakeCount).unwrap_or(0);
+        env.storage().instance().set(&DataKey::StakeCount, &(count + 1));
+
+        env.events().publish(
+            (symbol_short!("sb_stake"), staker),
+            (amount, tier as u32, lock_until, bonus_amount),
+        );
+
+        Ok(bonus_amount)
+    }
+
+    /// Claim staked tokens + bonus after the lock period expires.
+    pub fn claim(env: Env, staker: Address) -> Result<i128, CommonError> {
+        staker.require_auth();
+
+        let mut record: StakeRecord = env.storage().persistent()
+            .get(&DataKey::Stake(staker.clone()))
+            .ok_or(CommonError::KeyNotFound)?;
+
+        if record.claimed {
+            return Err(CommonError::AlreadyInitialized);
+        }
+
+        let now = env.ledger().timestamp();
+        if now < record.lock_until {
+            return Err(CommonError::NotAuthorized);
+        }
+
+        record.claimed = true;
+        env.storage().persistent().set(&DataKey::Stake(staker.clone()), &record);
+
+        let total_payout = record.amount + record.bonus_amount;
+
+        let mut total_paid: i128 = env.storage().instance().get(&DataKey::TotalBonusPaid).unwrap_or(0);
+        total_paid += record.bonus_amount;
+        env.storage().instance().set(&DataKey::TotalBonusPaid, &total_paid);
+
+        env.events().publish(
+            (symbol_short!("sb_claim"), staker),
+            (record.amount, record.bonus_amount, total_payout),
+        );
+
+        Ok(total_payout)
+    }
+
+    // ========================================================================
+    // View Functions
+    // ========================================================================
+
+    pub fn get_stake(env: Env, staker: Address) -> Option<StakeRecord> {
+        env.storage().persistent().get(&DataKey::Stake(staker))
+    }
+
+    pub fn get_reward_pool(env: Env) -> i128 {
+        env.storage().instance().get(&DataKey::RewardPool).unwrap_or(0)
+    }
+
+    pub fn get_total_staked(env: Env) -> i128 {
+        env.storage().instance().get(&DataKey::TotalStaked).unwrap_or(0)
+    }
+
+    pub fn get_total_bonus_paid(env: Env) -> i128 {
+        env.storage().instance().get(&DataKey::TotalBonusPaid).unwrap_or(0)
+    }
+
+    pub fn is_claimable(env: Env, staker: Address) -> bool {
+        if let Some(record) = env.storage().persistent().get::<_, StakeRecord>(&DataKey::Stake(staker)) {
+            !record.claimed && env.ledger().timestamp() >= record.lock_until
+        } else {
+            false
+        }
+    }
+
+    // ========================================================================
+    // Admin Functions
+    // ========================================================================
+
+    pub fn set_paused(env: Env, admin: Address, paused: bool) -> Result<(), CommonError> {
+        Self::require_admin(&env, &admin)?;
+
+        let mut config: StakingConfig = env.storage().instance().get(&DataKey::Config).unwrap();
+        config.paused = paused;
+        env.storage().instance().set(&DataKey::Config, &config);
+
+        env.events().publish(
+            (symbol_short!("sb_pause"), admin),
+            paused,
+        );
+
+        Ok(())
+    }
+
+    pub fn set_min_stake(env: Env, admin: Address, min_stake: i128) -> Result<(), CommonError> {
+        Self::require_admin(&env, &admin)?;
+
+        if min_stake <= 0 {
+            return Err(CommonError::OutOfRange);
+        }
+
+        let mut config: StakingConfig = env.storage().instance().get(&DataKey::Config).unwrap();
+        config.min_stake = min_stake;
+        env.storage().instance().set(&DataKey::Config, &config);
+
+        Ok(())
+    }
+
+    // ========================================================================
+    // Internal
+    // ========================================================================
+
+    fn require_admin(env: &Env, caller: &Address) -> Result<(), CommonError> {
+        let admin: Address = env.storage().instance()
+            .get(&DataKey::Admin)
+            .ok_or(CommonError::NotInitialized)?;
+
+        if admin != *caller {
+            return Err(CommonError::NotAuthorized);
+        }
+
+        caller.require_auth();
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env};
+
+    fn setup() -> (Env, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, StakingBonusesContract);
+        let client = StakingBonusesContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin).unwrap();
+        (env, contract_id, admin)
+    }
+
+    #[test]
+    fn test_initialize() {
+        let (env, contract_id, admin) = setup();
+        let client = StakingBonusesContractClient::new(&env, &contract_id);
+        assert_eq!(client.get_reward_pool(), 0);
+        assert_eq!(client.get_total_staked(), 0);
+    }
+
+    #[test]
+    fn test_double_initialize_fails() {
+        let (env, contract_id, admin) = setup();
+        let client = StakingBonusesContractClient::new(&env, &contract_id);
+        assert!(client.try_initialize(&admin).is_err());
+    }
+
+    #[test]
+    fn test_fund_reward_pool() {
+        let (env, contract_id, admin) = setup();
+        let client = StakingBonusesContractClient::new(&env, &contract_id);
+        client.fund_reward_pool(&admin, &5_000_000).unwrap();
+        assert_eq!(client.get_reward_pool(), 5_000_000);
+    }
+
+    #[test]
+    fn test_stake_and_bonus_calculation() {
+        let (env, contract_id, admin) = setup();
+        let client = StakingBonusesContractClient::new(&env, &contract_id);
+
+        client.fund_reward_pool(&admin, &10_000_000).unwrap();
+
+        let staker = Address::generate(&env);
+        // Stake 1_000_000 for 30 days → bonus = 5% = 50_000
+        let bonus = client.stake(&staker, &1_000_000, &LockTier::Days30).unwrap();
+        assert_eq!(bonus, 50_000);
+        assert_eq!(client.get_reward_pool(), 9_950_000);
+        assert_eq!(client.get_total_staked(), 1_000_000);
+    }
+
+    #[test]
+    fn test_claim_before_lock_fails() {
+        let (env, contract_id, admin) = setup();
+        let client = StakingBonusesContractClient::new(&env, &contract_id);
+
+        client.fund_reward_pool(&admin, &10_000_000).unwrap();
+        let staker = Address::generate(&env);
+        client.stake(&staker, &1_000_000, &LockTier::Days30).unwrap();
+
+        assert!(client.try_claim(&staker).is_err());
+        assert!(!client.is_claimable(&staker));
+    }
+
+    #[test]
+    fn test_claim_after_lock_succeeds() {
+        let (env, contract_id, admin) = setup();
+        let client = StakingBonusesContractClient::new(&env, &contract_id);
+
+        client.fund_reward_pool(&admin, &10_000_000).unwrap();
+        let staker = Address::generate(&env);
+        client.stake(&staker, &1_000_000, &LockTier::Days30).unwrap();
+
+        // Fast-forward past lock period
+        env.ledger().with_mut(|l| {
+            l.timestamp += TIER1_DAYS * SECONDS_PER_DAY + 1;
+        });
+
+        assert!(client.is_claimable(&staker));
+        let payout = client.claim(&staker).unwrap();
+        assert_eq!(payout, 1_050_000); // 1_000_000 + 50_000 bonus
+    }
+
+    #[test]
+    fn test_double_claim_fails() {
+        let (env, contract_id, admin) = setup();
+        let client = StakingBonusesContractClient::new(&env, &contract_id);
+
+        client.fund_reward_pool(&admin, &10_000_000).unwrap();
+        let staker = Address::generate(&env);
+        client.stake(&staker, &1_000_000, &LockTier::Days30).unwrap();
+
+        env.ledger().with_mut(|l| {
+            l.timestamp += TIER1_DAYS * SECONDS_PER_DAY + 1;
+        });
+
+        client.claim(&staker).unwrap();
+        assert!(client.try_claim(&staker).is_err());
+    }
+
+    #[test]
+    fn test_tier_rates() {
+        assert_eq!(LockTier::Days30.bonus_rate_bps(), 500);
+        assert_eq!(LockTier::Days90.bonus_rate_bps(), 1000);
+        assert_eq!(LockTier::Days180.bonus_rate_bps(), 1500);
+        assert_eq!(LockTier::Days365.bonus_rate_bps(), 2500);
+    }
+
+    #[test]
+    fn test_paused_stake_fails() {
+        let (env, contract_id, admin) = setup();
+        let client = StakingBonusesContractClient::new(&env, &contract_id);
+
+        client.fund_reward_pool(&admin, &10_000_000).unwrap();
+        client.set_paused(&admin, &true).unwrap();
+
+        let staker = Address::generate(&env);
+        assert!(client.try_stake(&staker, &1_000_000, &LockTier::Days30).is_err());
+    }
+}

--- a/contracts/token-launch-waitlist/Cargo.toml
+++ b/contracts/token-launch-waitlist/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "token-launch-waitlist"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { version = "21.0.0" }
+common-utils = { path = "../common-utils/contract" }
+
+[dev-dependencies]
+soroban-sdk = { version = "21.0.0", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true

--- a/contracts/token-launch-waitlist/src/lib.rs
+++ b/contracts/token-launch-waitlist/src/lib.rs
@@ -1,0 +1,516 @@
+//! # Token Launch Waitlist Contract
+//!
+//! Priority-queue waitlist for participating in new token staking launches.
+//!
+//! ## Features
+//!
+//! - **Token Launch Registration**: Admin registers upcoming token launches
+//! - **Waitlist Joining**: Users join via contract; position stored on-chain
+//! - **Priority Access**: FIFO queue; positions granted access at launch time
+//! - **Access Control**: Admin grants access to queued users when the token launches
+//! - **Off-chain Notifications**: Launch and access events emitted for indexers
+//!
+//! ## Flow
+//!
+//! 1. Admin creates a token launch entry
+//! 2. Users join the waitlist for that launch
+//! 3. Admin launches the token and grants access to the queue (FIFO)
+//! 4. Events are emitted for each access grant (off-chain notification hooks)
+
+#![no_std]
+
+use soroban_sdk::{
+    contract, contractimpl, contracttype, symbol_short,
+    Address, Env, String, Vec,
+};
+use common_utils::error::CommonError;
+
+// ============================================================================
+// Storage Keys
+// ============================================================================
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Initialized,
+
+    // Token launch registry
+    LaunchCount,
+    Launch(u64),              // launch_id → LaunchInfo
+
+    // Per-launch waitlists (FIFO queue stored as Vec)
+    Waitlist(u64),            // launch_id → Vec<Address>
+    UserPosition(u64, Address), // (launch_id, user) → queue position (1-based)
+
+    // Access granted set
+    AccessGranted(u64, Address), // (launch_id, user) → bool
+
+    // Global stats
+    TotalRegistrations,
+}
+
+// ============================================================================
+// Data Types
+// ============================================================================
+
+/// Status of a token launch
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[contracttype]
+pub enum LaunchStatus {
+    /// Waitlist open
+    Open = 0,
+    /// Launch in progress — access being granted
+    Launching = 1,
+    /// Fully launched
+    Launched = 2,
+    /// Cancelled
+    Cancelled = 3,
+}
+
+/// Information about a token launch
+#[derive(Clone)]
+#[contracttype]
+pub struct LaunchInfo {
+    pub launch_id: u64,
+    pub token_symbol: String,
+    pub description: String,
+    pub status: LaunchStatus,
+    pub created_at: u64,
+    pub launched_at: u64,
+    /// Maximum waitlist size (0 = unlimited)
+    pub max_waitlist: u32,
+    /// Number of users granted access so far
+    pub access_granted_count: u32,
+    /// Total users on the waitlist
+    pub waitlist_size: u32,
+}
+
+// ============================================================================
+// Contract
+// ============================================================================
+
+#[contract]
+pub struct TokenLaunchWaitlistContract;
+
+#[contractimpl]
+impl TokenLaunchWaitlistContract {
+    /// Initialize the contract.
+    pub fn initialize(env: Env, admin: Address) -> Result<(), CommonError> {
+        if env.storage().instance().has(&DataKey::Initialized) {
+            return Err(CommonError::AlreadyInitialized);
+        }
+
+        admin.require_auth();
+
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::LaunchCount, &0u64);
+        env.storage().instance().set(&DataKey::TotalRegistrations, &0u64);
+        env.storage().instance().set(&DataKey::Initialized, &true);
+
+        env.events().publish(
+            (symbol_short!("tlw_init"), admin),
+            symbol_short!("ok"),
+        );
+
+        Ok(())
+    }
+
+    /// Admin registers a new token launch and opens its waitlist.
+    pub fn create_launch(
+        env: Env,
+        admin: Address,
+        token_symbol: String,
+        description: String,
+        max_waitlist: u32,
+    ) -> Result<u64, CommonError> {
+        Self::require_admin(&env, &admin)?;
+
+        let launch_id: u64 = env.storage().instance().get(&DataKey::LaunchCount).unwrap_or(0);
+
+        let info = LaunchInfo {
+            launch_id,
+            token_symbol: token_symbol.clone(),
+            description,
+            status: LaunchStatus::Open,
+            created_at: env.ledger().timestamp(),
+            launched_at: 0,
+            max_waitlist,
+            access_granted_count: 0,
+            waitlist_size: 0,
+        };
+
+        env.storage().persistent().set(&DataKey::Launch(launch_id), &info);
+        env.storage().instance().set(&DataKey::LaunchCount, &(launch_id + 1));
+
+        env.events().publish(
+            (symbol_short!("tlw_new"), admin),
+            (launch_id, token_symbol),
+        );
+
+        Ok(launch_id)
+    }
+
+    /// Join the waitlist for a token launch.
+    ///
+    /// Users are added to a FIFO queue. Their position is stored on-chain.
+    pub fn join_waitlist(env: Env, user: Address, launch_id: u64) -> Result<u32, CommonError> {
+        user.require_auth();
+
+        let mut info: LaunchInfo = env.storage().persistent()
+            .get(&DataKey::Launch(launch_id))
+            .ok_or(CommonError::KeyNotFound)?;
+
+        if info.status != LaunchStatus::Open {
+            return Err(CommonError::NotAuthorized);
+        }
+
+        // Prevent duplicate join
+        if env.storage().persistent().has(&DataKey::UserPosition(launch_id, user.clone())) {
+            return Err(CommonError::AlreadyInitialized);
+        }
+
+        // Enforce max waitlist cap
+        if info.max_waitlist > 0 && info.waitlist_size >= info.max_waitlist {
+            return Err(CommonError::OutOfRange);
+        }
+
+        // Append to FIFO queue; position is 1-based
+        let position = info.waitlist_size + 1;
+        let mut queue: Vec<Address> = env.storage().persistent()
+            .get(&DataKey::Waitlist(launch_id))
+            .unwrap_or_else(|| Vec::new(&env));
+        queue.push_back(user.clone());
+        env.storage().persistent().set(&DataKey::Waitlist(launch_id), &queue);
+
+        env.storage().persistent().set(
+            &DataKey::UserPosition(launch_id, user.clone()),
+            &position,
+        );
+
+        info.waitlist_size = position;
+        env.storage().persistent().set(&DataKey::Launch(launch_id), &info);
+
+        let total: u64 = env.storage().instance().get(&DataKey::TotalRegistrations).unwrap_or(0);
+        env.storage().instance().set(&DataKey::TotalRegistrations, &(total + 1));
+
+        env.events().publish(
+            (symbol_short!("tlw_join"), user),
+            (launch_id, position),
+        );
+
+        Ok(position)
+    }
+
+    /// Admin grants access to the next `count` users in the FIFO queue.
+    ///
+    /// Emits a `tlw_access` event per user for off-chain notification hooks.
+    pub fn grant_access(
+        env: Env,
+        admin: Address,
+        launch_id: u64,
+        count: u32,
+    ) -> Result<u32, CommonError> {
+        Self::require_admin(&env, &admin)?;
+
+        let mut info: LaunchInfo = env.storage().persistent()
+            .get(&DataKey::Launch(launch_id))
+            .ok_or(CommonError::KeyNotFound)?;
+
+        if info.status == LaunchStatus::Cancelled || info.status == LaunchStatus::Launched {
+            return Err(CommonError::NotAuthorized);
+        }
+
+        // Transition to Launching if still Open
+        if info.status == LaunchStatus::Open {
+            info.status = LaunchStatus::Launching;
+        }
+
+        let queue: Vec<Address> = env.storage().persistent()
+            .get(&DataKey::Waitlist(launch_id))
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let start = info.access_granted_count as usize;
+        let granted_before = info.access_granted_count;
+        let queue_len = queue.len() as u32;
+
+        let mut granted = 0u32;
+        let mut idx = start;
+        while granted < count && (granted_before + granted) < queue_len {
+            let user = queue.get(idx as u32).unwrap();
+            env.storage().persistent().set(
+                &DataKey::AccessGranted(launch_id, user.clone()),
+                &true,
+            );
+            env.events().publish(
+                (symbol_short!("tlw_access"), user),
+                (launch_id, granted_before + granted + 1),
+            );
+            granted += 1;
+            idx += 1;
+        }
+
+        info.access_granted_count += granted;
+        env.storage().persistent().set(&DataKey::Launch(launch_id), &info);
+
+        Ok(granted)
+    }
+
+    /// Admin marks a launch as fully launched.
+    pub fn finalize_launch(env: Env, admin: Address, launch_id: u64) -> Result<(), CommonError> {
+        Self::require_admin(&env, &admin)?;
+
+        let mut info: LaunchInfo = env.storage().persistent()
+            .get(&DataKey::Launch(launch_id))
+            .ok_or(CommonError::KeyNotFound)?;
+
+        if info.status == LaunchStatus::Cancelled || info.status == LaunchStatus::Launched {
+            return Err(CommonError::NotAuthorized);
+        }
+
+        info.status = LaunchStatus::Launched;
+        info.launched_at = env.ledger().timestamp();
+        env.storage().persistent().set(&DataKey::Launch(launch_id), &info);
+
+        env.events().publish(
+            (symbol_short!("tlw_done"), admin),
+            (launch_id, info.launched_at),
+        );
+
+        Ok(())
+    }
+
+    /// Admin cancels a launch.
+    pub fn cancel_launch(env: Env, admin: Address, launch_id: u64) -> Result<(), CommonError> {
+        Self::require_admin(&env, &admin)?;
+
+        let mut info: LaunchInfo = env.storage().persistent()
+            .get(&DataKey::Launch(launch_id))
+            .ok_or(CommonError::KeyNotFound)?;
+
+        if info.status == LaunchStatus::Launched {
+            return Err(CommonError::NotAuthorized);
+        }
+
+        info.status = LaunchStatus::Cancelled;
+        env.storage().persistent().set(&DataKey::Launch(launch_id), &info);
+
+        env.events().publish(
+            (symbol_short!("tlw_cxl"), admin),
+            launch_id,
+        );
+
+        Ok(())
+    }
+
+    // ========================================================================
+    // View Functions
+    // ========================================================================
+
+    pub fn get_launch(env: Env, launch_id: u64) -> Option<LaunchInfo> {
+        env.storage().persistent().get(&DataKey::Launch(launch_id))
+    }
+
+    pub fn get_waitlist(env: Env, launch_id: u64) -> Vec<Address> {
+        env.storage().persistent()
+            .get(&DataKey::Waitlist(launch_id))
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    pub fn get_position(env: Env, launch_id: u64, user: Address) -> Option<u32> {
+        env.storage().persistent().get(&DataKey::UserPosition(launch_id, user))
+    }
+
+    pub fn has_access(env: Env, launch_id: u64, user: Address) -> bool {
+        env.storage().persistent()
+            .get(&DataKey::AccessGranted(launch_id, user))
+            .unwrap_or(false)
+    }
+
+    pub fn get_launch_count(env: Env) -> u64 {
+        env.storage().instance().get(&DataKey::LaunchCount).unwrap_or(0)
+    }
+
+    pub fn get_total_registrations(env: Env) -> u64 {
+        env.storage().instance().get(&DataKey::TotalRegistrations).unwrap_or(0)
+    }
+
+    // ========================================================================
+    // Internal
+    // ========================================================================
+
+    fn require_admin(env: &Env, caller: &Address) -> Result<(), CommonError> {
+        let admin: Address = env.storage().instance()
+            .get(&DataKey::Admin)
+            .ok_or(CommonError::NotInitialized)?;
+
+        if admin != *caller {
+            return Err(CommonError::NotAuthorized);
+        }
+
+        caller.require_auth();
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+    fn setup() -> (Env, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, TokenLaunchWaitlistContract);
+        let client = TokenLaunchWaitlistContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin).unwrap();
+        (env, contract_id, admin)
+    }
+
+    #[test]
+    fn test_initialize() {
+        let (env, contract_id, _) = setup();
+        let client = TokenLaunchWaitlistContractClient::new(&env, &contract_id);
+        assert_eq!(client.get_launch_count(), 0);
+        assert_eq!(client.get_total_registrations(), 0);
+    }
+
+    #[test]
+    fn test_create_launch() {
+        let (env, contract_id, admin) = setup();
+        let client = TokenLaunchWaitlistContractClient::new(&env, &contract_id);
+
+        let symbol = String::from_str(&env, "LUMI");
+        let desc = String::from_str(&env, "New LUMI token staking launch");
+        let launch_id = client.create_launch(&admin, &symbol, &desc, &100).unwrap();
+
+        assert_eq!(launch_id, 0);
+        assert_eq!(client.get_launch_count(), 1);
+
+        let info = client.get_launch(&launch_id).unwrap();
+        assert_eq!(info.status, LaunchStatus::Open);
+        assert_eq!(info.waitlist_size, 0);
+    }
+
+    #[test]
+    fn test_join_waitlist() {
+        let (env, contract_id, admin) = setup();
+        let client = TokenLaunchWaitlistContractClient::new(&env, &contract_id);
+
+        let symbol = String::from_str(&env, "LUMI");
+        let desc = String::from_str(&env, "Test");
+        let launch_id = client.create_launch(&admin, &symbol, &desc, &0).unwrap();
+
+        let user1 = Address::generate(&env);
+        let user2 = Address::generate(&env);
+
+        let pos1 = client.join_waitlist(&user1, &launch_id).unwrap();
+        let pos2 = client.join_waitlist(&user2, &launch_id).unwrap();
+
+        assert_eq!(pos1, 1);
+        assert_eq!(pos2, 2);
+        assert_eq!(client.get_total_registrations(), 2);
+        assert_eq!(client.get_position(&launch_id, &user1).unwrap(), 1);
+    }
+
+    #[test]
+    fn test_duplicate_join_fails() {
+        let (env, contract_id, admin) = setup();
+        let client = TokenLaunchWaitlistContractClient::new(&env, &contract_id);
+
+        let symbol = String::from_str(&env, "LUMI");
+        let desc = String::from_str(&env, "Test");
+        let launch_id = client.create_launch(&admin, &symbol, &desc, &0).unwrap();
+
+        let user = Address::generate(&env);
+        client.join_waitlist(&user, &launch_id).unwrap();
+        assert!(client.try_join_waitlist(&user, &launch_id).is_err());
+    }
+
+    #[test]
+    fn test_max_waitlist_cap() {
+        let (env, contract_id, admin) = setup();
+        let client = TokenLaunchWaitlistContractClient::new(&env, &contract_id);
+
+        let symbol = String::from_str(&env, "LUMI");
+        let desc = String::from_str(&env, "Test");
+        let launch_id = client.create_launch(&admin, &symbol, &desc, &2).unwrap();
+
+        let user1 = Address::generate(&env);
+        let user2 = Address::generate(&env);
+        let user3 = Address::generate(&env);
+
+        client.join_waitlist(&user1, &launch_id).unwrap();
+        client.join_waitlist(&user2, &launch_id).unwrap();
+        assert!(client.try_join_waitlist(&user3, &launch_id).is_err());
+    }
+
+    #[test]
+    fn test_grant_access_fifo_order() {
+        let (env, contract_id, admin) = setup();
+        let client = TokenLaunchWaitlistContractClient::new(&env, &contract_id);
+
+        let symbol = String::from_str(&env, "LUMI");
+        let desc = String::from_str(&env, "Test");
+        let launch_id = client.create_launch(&admin, &symbol, &desc, &0).unwrap();
+
+        let user1 = Address::generate(&env);
+        let user2 = Address::generate(&env);
+        let user3 = Address::generate(&env);
+
+        client.join_waitlist(&user1, &launch_id).unwrap();
+        client.join_waitlist(&user2, &launch_id).unwrap();
+        client.join_waitlist(&user3, &launch_id).unwrap();
+
+        // Grant access to first 2
+        let granted = client.grant_access(&admin, &launch_id, &2).unwrap();
+        assert_eq!(granted, 2);
+        assert!(client.has_access(&launch_id, &user1));
+        assert!(client.has_access(&launch_id, &user2));
+        assert!(!client.has_access(&launch_id, &user3));
+
+        // Grant remaining
+        let granted2 = client.grant_access(&admin, &launch_id, &10).unwrap();
+        assert_eq!(granted2, 1);
+        assert!(client.has_access(&launch_id, &user3));
+    }
+
+    #[test]
+    fn test_finalize_launch() {
+        let (env, contract_id, admin) = setup();
+        let client = TokenLaunchWaitlistContractClient::new(&env, &contract_id);
+
+        let symbol = String::from_str(&env, "LUMI");
+        let desc = String::from_str(&env, "Test");
+        let launch_id = client.create_launch(&admin, &symbol, &desc, &0).unwrap();
+
+        client.finalize_launch(&admin, &launch_id).unwrap();
+        let info = client.get_launch(&launch_id).unwrap();
+        assert_eq!(info.status, LaunchStatus::Launched);
+    }
+
+    #[test]
+    fn test_cancel_launch() {
+        let (env, contract_id, admin) = setup();
+        let client = TokenLaunchWaitlistContractClient::new(&env, &contract_id);
+
+        let symbol = String::from_str(&env, "LUMI");
+        let desc = String::from_str(&env, "Test");
+        let launch_id = client.create_launch(&admin, &symbol, &desc, &0).unwrap();
+
+        let user = Address::generate(&env);
+        client.join_waitlist(&user, &launch_id).unwrap();
+        client.cancel_launch(&admin, &launch_id).unwrap();
+
+        let info = client.get_launch(&launch_id).unwrap();
+        assert_eq!(info.status, LaunchStatus::Cancelled);
+
+        // Cannot join cancelled launch
+        let user2 = Address::generate(&env);
+        assert!(client.try_join_waitlist(&user2, &launch_id).is_err());
+    }
+}


### PR DESCRIPTION

Closes #266
Closes #267
Closes #268
Closes #269

- contracts/staking-bonuses: duration-based staking bonuses with tier lock periods (30/90/180/365 days), time-locked claims, and admin reward pool

- contracts/referral-rewards: on-chain referral tracking with fraud-proof admin confirmation flow, reward pool, and claimable balances

- contracts/token-launch-waitlist: FIFO priority waitlist for new token staking launches with admin-gated access granting and event-based off-chain notifications

- contracts/credit-score-nft: added verifiable credit_score field, transfer with owner/operator approval, marketplace list/delist/buy, and score update function; updated tests